### PR TITLE
Add trailing slashes for API endpoints

### DIFF
--- a/src/carbon_txt_validator/web/config/api.py
+++ b/src/carbon_txt_validator/web/config/api.py
@@ -34,7 +34,7 @@ class CarbonTextUrlSubmission(Schema):
 
 
 @ninja_api.post(
-    "/validate/file",
+    "/validate/file/",
     description="Accept contents of a carbon.txt file and validate it.",
 )
 def validate_contents(
@@ -68,7 +68,7 @@ def validate_contents(
 
 
 @ninja_api.post(
-    "/validate/url", description="Fetch a file at a given URL and validate it."
+    "/validate/url/", description="Fetch a file at a given URL and validate it."
 )
 def validate_url(
     request: HttpRequest, carbon_txt_url_data: CarbonTextUrlSubmission

--- a/src/carbon_txt_validator/web/config/settings/base.py
+++ b/src/carbon_txt_validator/web/config/settings/base.py
@@ -81,6 +81,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "carbon_txt_validator.web.middleware.AddTrailingSlashMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"

--- a/src/carbon_txt_validator/web/middleware.py
+++ b/src/carbon_txt_validator/web/middleware.py
@@ -1,0 +1,10 @@
+class AddTrailingSlashMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if not request.path.endswith("/"):
+            request.path_info = request.path = f"{request.path}/"
+
+        response = self.get_response(request)
+        return response

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 def test_hitting_validate_endpoint_ok(live_server, shorter_carbon_txt_string):
-    api_url = f"{live_server.url}/api/validate/file"
+    api_url = f"{live_server.url}/api/validate/file/"
     data = {"text_contents": shorter_carbon_txt_string}
     res = httpx.post(api_url, json=data, follow_redirects=True)
     rich.inspect(res)
@@ -19,7 +19,7 @@ def test_hitting_validate_endpoint_fail(live_server):
     )
 
     with open(path_to_failing_file) as toml_file:
-        api_url = f"{live_server.url}/api/validate/file"
+        api_url = f"{live_server.url}/api/validate/file/"
         data = {"text_contents": toml_file.read()}
         res = httpx.post(api_url, json=data, follow_redirects=True)
         rich.inspect(res)
@@ -28,7 +28,7 @@ def test_hitting_validate_endpoint_fail(live_server):
 
 
 def test_hitting_validate_url_endpoint_ok(live_server):
-    api_url = f"{live_server.url}/api/validate/url"
+    api_url = f"{live_server.url}/api/validate/url/"
     data = {"url": "https://aremythirdpartiesgreen.com/carbon.txt"}
     res = httpx.post(api_url, json=data, follow_redirects=True)
     rich.inspect(res)
@@ -37,7 +37,7 @@ def test_hitting_validate_url_endpoint_ok(live_server):
 
 
 def test_hitting_validate_url_endpoint_fail(live_server):
-    api_url = f"{live_server.url}/api/validate/url"
+    api_url = f"{live_server.url}/api/validate/url/"
     data = {"url": "https://aremythirdpartiesgreen.com/carbon.txt"}
     res = httpx.post(api_url, json=data, follow_redirects=True)
     rich.inspect(res)


### PR DESCRIPTION
There is a bit of work needed to make endpoints agnostic about the trailing slash.

Fixes #8