### PR TITLE
Add cors support and tidy up optional slash middleware

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,7 @@
+import pathlib
+
+import tomllib
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
@@ -9,7 +13,11 @@
 project = "Carbon.txt Validator"
 copyright = "2024, Chris Adams, Fershad Irani, Hannah Smith"
 author = "Chris Adams, Fershad Irani, Hannah Smith"
-release = "0.0.2"
+
+pypproject_toml = pathlib.Path(".").absolute().parent / "pyproject.toml"
+parsed_toml = tomllib.loads(pypproject_toml.read_text())
+
+release = parsed_toml["project"]["version"]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,3 +32,26 @@ You need to set the Django SECRET KEY in production to a non default value, or t
 
 You can do this via setting an environment variable directly, or declaring it in a .env file in the same directory as where you are running the tool.
 ```
+
+### CORS support
+
+By default, when the validator server is run, it has CORS support, and accepts
+requests coming from `http://localhost:8080` and `http://127.0.0.1:8000`.
+
+```python
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+]
+```
+
+To accept responses from **all** origins set the `CORS_ALLOW_ALL_ORIGINS` to
+true.
+
+```
+CORS_ALLOW_ALL_ORIGINS = True
+```
+
+```{admonition} TODO
+Add support for setting new CORS ALLOWED ORIGINS in production once we deploy to production.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carbon-txt-validator"
-version = "0.0.2"
+version = "0.0.3"
 description = "A validator for carbon.txt files, by the Green Web Foundation"
 authors = [
     { name = "Chris Adams" },
@@ -12,6 +12,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 classifiers = ["License :: OSI Approved :: Apache Software License"]
 dependencies = [
+    "django-cors-headers>=4.6.0",
     "django-environ>=0.11.2",
     "django-ninja>=1.3.0",
     "dnspython>=2.7.0",

--- a/src/carbon_txt_validator/web/config/settings/base.py
+++ b/src/carbon_txt_validator/web/config/settings/base.py
@@ -71,11 +71,13 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "corsheaders",
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/src/carbon_txt_validator/web/config/settings/development.py
+++ b/src/carbon_txt_validator/web/config/settings/development.py
@@ -4,3 +4,16 @@ ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
 
 WSGI_APPLICATION = "carbon_txt_validator.web.config.wsgi.application"
 ROOT_URLCONF = "carbon_txt_validator.web.config.urls"
+
+# CORS
+# for docs see:
+# https://github.com/adamchainz/django-cors-headers
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+]
+
+# Uncomment this to allow connections from any 'local' domain, like
+# if you are using '.dev' or '.local' domain with a reverse proxy
+# like Caddy or Nginx
+# CORS_ALLOW_ALL_ORIGINS = True

--- a/src/carbon_txt_validator/web/middleware.py
+++ b/src/carbon_txt_validator/web/middleware.py
@@ -1,9 +1,25 @@
+from django.http import HttpRequest, HttpResponse
+from typing import Callable
+
+
 class AddTrailingSlashMiddleware:
-    def __init__(self, get_response):
+    """
+    Middleware to add a trailing slash to specific API endpoints, but
+    keep the other endpoints like /api/docs and api/openapi.json as they are.
+
+    For more, see the links below
+    https://github.com/vitalik/django-ninja/issues/1058
+    https://docs.djangoproject.com/en/5.1/topics/http/middleware/
+    """
+
+    def __init__(self, get_response: Callable):
         self.get_response = get_response
 
-    def __call__(self, request):
-        if not request.path.endswith("/"):
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        # Note: 'validate' is the endpoint that requires a trailing slash.
+        # we still want /api/docs and /api/openapi.json to work
+        # without a trailing slash.
+        if "api/validate" in request.path and not request.path.endswith("/"):
             request.path_info = request.path = f"{request.path}/"
 
         response = self.get_response(request)

--- a/tests/api_external.py
+++ b/tests/api_external.py
@@ -9,7 +9,7 @@ def check_carbon_txt_contents():
     ) as toml_file:
         toml_contents = toml_file.read()
 
-        api_url = "http://127.0.0.1:8000/api/validate/file"
+        api_url = "http://127.0.0.1:8000/api/validate/file/"
         data = {"domain": "string", "text_contents": toml_contents}
         res = httpx.post(api_url, json=data, follow_redirects=True)
         rich.print(res)
@@ -17,7 +17,7 @@ def check_carbon_txt_contents():
 
 
 def check_carbon_txt_url():
-    api_url = "http://127.0.0.1:8000/api/validate/url"
+    api_url = "http://127.0.0.1:8000/api/validate/url/"
     data = {"url": "https://aremythirdpartiesgreen.com/carbon.txt"}
     res = httpx.post(api_url, json=data, follow_redirects=True)
     rich.print(res)

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -1,11 +1,15 @@
-import httpx
-import rich
-
 from pathlib import Path
 
+import httpx
+import pytest
+import rich
 
-def test_hitting_validate_endpoint_ok(live_server, shorter_carbon_txt_string):
-    api_url = f"{live_server.url}/api/validate/file/"
+
+@pytest.mark.parametrize("url_suffix", ["", "/"])
+def test_hitting_validate_endpoint_ok(
+    live_server, shorter_carbon_txt_string, url_suffix
+):
+    api_url = f"{live_server.url}/api/validate/file{url_suffix}"
     data = {"text_contents": shorter_carbon_txt_string}
     res = httpx.post(api_url, json=data, follow_redirects=True)
     rich.inspect(res)
@@ -13,13 +17,14 @@ def test_hitting_validate_endpoint_ok(live_server, shorter_carbon_txt_string):
     assert res.status_code == 200
 
 
-def test_hitting_validate_endpoint_fail(live_server):
+@pytest.mark.parametrize("url_suffix", ["", "/"])
+def test_hitting_validate_endpoint_fail(live_server, url_suffix):
     path_to_failing_file = (
         Path() / "tests" / "fixtures" / "aremythirdpartiesgreen.com.carbon-txt.toml"
     )
 
     with open(path_to_failing_file) as toml_file:
-        api_url = f"{live_server.url}/api/validate/file/"
+        api_url = f"{live_server.url}/api/validate/file{url_suffix}"
         data = {"text_contents": toml_file.read()}
         res = httpx.post(api_url, json=data, follow_redirects=True)
         rich.inspect(res)
@@ -27,8 +32,9 @@ def test_hitting_validate_endpoint_fail(live_server):
         assert res.status_code == 200
 
 
-def test_hitting_validate_url_endpoint_ok(live_server):
-    api_url = f"{live_server.url}/api/validate/url/"
+@pytest.mark.parametrize("url_suffix", ["", "/"])
+def test_hitting_validate_url_endpoint_ok(live_server, url_suffix):
+    api_url = f"{live_server.url}/api/validate/url{url_suffix}"
     data = {"url": "https://aremythirdpartiesgreen.com/carbon.txt"}
     res = httpx.post(api_url, json=data, follow_redirects=True)
     rich.inspect(res)
@@ -36,8 +42,9 @@ def test_hitting_validate_url_endpoint_ok(live_server):
     assert res.status_code == 200
 
 
-def test_hitting_validate_url_endpoint_fail(live_server):
-    api_url = f"{live_server.url}/api/validate/url/"
+@pytest.mark.parametrize("url_suffix", ["", "/"])
+def test_hitting_validate_url_endpoint_fail(live_server, url_suffix):
+    api_url = f"{live_server.url}/api/validate/url{url_suffix}"
     data = {"url": "https://aremythirdpartiesgreen.com/carbon.txt"}
     res = httpx.post(api_url, json=data, follow_redirects=True)
     rich.inspect(res)

--- a/uv.lock
+++ b/uv.lock
@@ -80,9 +80,10 @@ wheels = [
 
 [[package]]
 name = "carbon-txt-validator"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
+    { name = "django-cors-headers" },
     { name = "django-environ" },
     { name = "django-ninja" },
     { name = "dnspython" },
@@ -107,6 +108,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "django-cors-headers", specifier = ">=4.6.0" },
     { name = "django-environ", specifier = ">=0.11.2" },
     { name = "django-ninja", specifier = ">=1.3.0" },
     { name = "dnspython", specifier = ">=2.7.0" },
@@ -234,6 +236,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9c/e5/a06e20c963b280af4aa9432bc694fbdeb1c8df9e28c2ffd5fbb71c4b1bec/Django-5.1.2.tar.gz", hash = "sha256:bd7376f90c99f96b643722eee676498706c9fd7dc759f55ebfaf2c08ebcdf4f0", size = 10711674 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/b8/f205f2b8c44c6cdc555c4f56bbe85ceef7f67c0cf1caa8abe078bb7e32bd/Django-5.1.2-py3-none-any.whl", hash = "sha256:f11aa87ad8d5617171e3f77e1d5d16f004b79a2cf5d2e1d2b97a6a1f8e9ba5ed", size = 8276058 },
+]
+
+[[package]]
+name = "django-cors-headers"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/e5/3b67fc05b9c02b926411436dfc553829bc00843706ce7f99752433017f47/django_cors_headers-4.6.0.tar.gz", hash = "sha256:14d76b4b4c8d39375baeddd89e4f08899051eeaf177cb02a29bd6eae8cf63aa8", size = 20961 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/73/689532cf164ab10ed1521d825ea156656520cec98886c8d2ac1ce8829220/django_cors_headers-4.6.0-py3-none-any.whl", hash = "sha256:8edbc0497e611c24d5150e0055d3b178c6534b8ed826fb6f53b21c63f5d48ba3", size = 12791 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request includes several updates to the Carbon.txt Validator project, focusing on adding CORS support, updating version numbers, and refining the documentation and configuration files. The most important changes are summarized below:

### CORS Support:

* Added CORS support configuration in `docs/deployment.md` to allow requests from specific local origins and provide an option to accept requests from all origins.
* Updated `pyproject.toml` to include `django-cors-headers` as a dependency.
* Enabled CORS middleware in `src/carbon_txt_validator/web/config/settings/base.py`.
* Configured CORS settings in `src/carbon_txt_validator/web/config/settings/development.py` for development purposes.

### Version Updates:

* Updated the project version from `0.0.2` to `0.0.3` in `pyproject.toml`.
* Modified `docs/conf.py` to dynamically read the project version from `pyproject.toml` using `tomllib`.

### Minor Fixes:

* Corrected API endpoint URLs in `tests/api_external.py` to include trailing slashes.