### PR TITLE
Ca gracefully fail server

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,18 @@ You can now run the command line tool with `uv run carbon-txt`
 
 ### Running outside a project
 
-If you have uv installed, you can run the command line tool using the slightly
-longer `carbon-txt` command instead (we need a cli command that shares the name
-of the project).
-
-This will download the latest published version from pypi and run the cli:
+If you have uv installed, you can run the command line tool like so:
 
 ```
+# check a file
 uv tool run carbon-txt validate ./path/to/file
+
+# run a server
+uv tool run carbon-txt serve
 ```
+
+This will download the latest published version from pypi and run the
+corresponding CLI command
 
 ## With the HTTP API
 

--- a/justfile
+++ b/justfile
@@ -33,3 +33,6 @@ docs-watch:
 build:
   rm -rf ./dist
   uv build
+
+publish: build
+  uv run twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carbon-txt"
-version = "0.0.4"
+version = "0.0.5"
 description = "A command line tool containing a validator for carbon.txt files, by the Green Web Foundation"
 authors = [
     { name = "Chris Adams" },

--- a/src/carbon_txt/exceptions.py
+++ b/src/carbon_txt/exceptions.py
@@ -1,0 +1,4 @@
+class InsecureKeyException(Exception):
+    """Raised when the default SECRET_KEY is used in a production django server environment"""
+
+    pass

--- a/src/carbon_txt/web/config/settings/base.py
+++ b/src/carbon_txt/web/config/settings/base.py
@@ -16,7 +16,10 @@ import os
 
 import logging
 
+from carbon_txt.exceptions import InsecureKeyException
+
 logger = logging.getLogger(__name__)
+
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent.parent
@@ -38,8 +41,8 @@ settings_module = os.getenv("DJANGO_SETTINGS_MODULE")
 
 # if we are in a production environment, we need to ensure that the SECRET_KEY is set
 if env("SECRET_KEY") == DEFAULT_SECRET_KEY and "settings.production" in settings_module:
-    raise RuntimeError(
-        "you are using the default SECRET_KEY value in a production environment. "
+    raise InsecureKeyException(
+        "You are using the default SECRET_KEY value in a production environment. "
         "Please set a proper SECRET_KEY, via the SECRET_KEY environment variable."
     )
 

--- a/src/carbon_txt/web/config/settings/development.py
+++ b/src/carbon_txt/web/config/settings/development.py
@@ -1,6 +1,6 @@
 from .base import *  # noqa
 
-ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
+ALLOWED_HOSTS = ["127.0.0.1", "localhost", ".localhost", ".greenweb.org"]
 
 WSGI_APPLICATION = "carbon_txt.web.config.wsgi.application"
 ROOT_URLCONF = "carbon_txt.web.config.urls"

--- a/src/carbon_txt/web/config/settings/production.py
+++ b/src/carbon_txt/web/config/settings/production.py
@@ -1,7 +1,7 @@
 from .base import *  # noqa
 
 DEBUG = False
-ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
+ALLOWED_HOSTS = ["127.0.0.1", "localhost", ".localhost", ".greenweb.org"]
 
 WSGI_APPLICATION = "carbon_txt.web.config.wsgi.application"
 ROOT_URLCONF = "carbon_txt.web.config.urls"

--- a/uv.lock
+++ b/uv.lock
@@ -89,7 +89,7 @@ wheels = [
 
 [[package]]
 name = "carbon-txt"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "django-cors-headers" },


### PR DESCRIPTION
This pull request includes several updates to the `carbon-txt` project, focusing on improving the command line tool's functionality, enhancing error handling, and updating project settings. The most important changes include adding a new exception for insecure keys, updating the command line tool usage instructions, and modifying the `serve` command to support custom Django settings.

### Command Line Tool Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R57): Updated instructions for running the command line tool with `uv run carbon-txt` and added examples for validating files and running a server.

### Error Handling Improvements:
* [`src/carbon_txt/cli.py`](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaR142-R165): Added handling for `InsecureKeyException` and general exceptions to provide clearer error messages and guidance on raising issues. [[1]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaR142-R165) [[2]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaR175-R191)
* [`src/carbon_txt/exceptions.py`](diffhunk://#diff-31fca68fd6e7efba810d6cf2f090d68ea68109f7a2f60bfb98de905ac3842be2R1-R4): Introduced `InsecureKeyException` to handle cases where the default `SECRET_KEY` is used in a production environment.
* [`src/carbon_txt/web/config/settings/base.py`](diffhunk://#diff-ccf5495a22ae8d4d5794a784e145dcebd0b028815a5e8ac2fe80dac75af7412dL41-R45): Modified to raise `InsecureKeyException` instead of `RuntimeError` when the default `SECRET_KEY` is used in production.

### Project Configuration Updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Bumped version from `0.0.4` to `0.0.5`.
* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R36-R38): Added a `publish` task to build and publish the package using `twine`.
* `src/carbon_txt/web/config/settings/development.py` and `src/carbon_txt/web/config/settings/production.py`: Updated `ALLOWED_HOSTS` to include `.localhost` and `.greenweb.org`. [[1]](diffhunk://#diff-396aba5177cd200900021df2cf12a1151c431b4ccfc7a3e40f9207cff47219cdL3-R3) [[2]](diffhunk://#diff-507dc1e5325b04d2c850d1d5d4c7ba8901bea0bf4f428f64ad39878e13bb0203L4-R4)