### PR TITLE
Add support for  json schema in API and CLI

### DIFF
--- a/src/carbon_txt/cli.py
+++ b/src/carbon_txt/cli.py
@@ -24,6 +24,8 @@ app.add_typer(
     help="Validate carbon.txt files, either online, or locally.",
 )
 
+err_console = rich.console.Console(stderr=True)
+
 
 file_finder = finders.FileFinder()
 parser = parsers_toml.CarbonTxtParser()
@@ -103,8 +105,6 @@ def validate_file(
         _log_validated_carbon_txt_object(validation_results)
         return 1
 
-    return parsed_result
-
 
 @app.command()
 def schema():
@@ -113,8 +113,13 @@ def schema():
     """
     schema = CarbonTxtFile.model_json_schema()
 
-    rich.print(json.dumps(schema, indent=2))
-    return schema
+    err_console.print("JSON Schema for a carbon.txt file: \n")
+
+    if sys.stdout.isatty():
+        rich.print(json.dumps(schema, indent=2))
+    else:
+        print(json.dumps(schema, indent=2))
+    return 0
 
 
 def configure_django(

--- a/src/carbon_txt/cli.py
+++ b/src/carbon_txt/cli.py
@@ -108,6 +108,9 @@ def validate_file(
 
 @app.command()
 def schema():
+    """
+    Generate a JSON Schema representation of a carbon.txt file for validation
+    """
     schema = CarbonTxtFile.model_json_schema()
 
     rich.print(json.dumps(schema, indent=2))

--- a/src/carbon_txt/cli.py
+++ b/src/carbon_txt/cli.py
@@ -1,7 +1,7 @@
+import json
 import logging
 import os
 import sys
-
 from pathlib import Path
 
 import django
@@ -104,6 +104,14 @@ def validate_file(
         return 1
 
     return parsed_result
+
+
+@app.command()
+def schema():
+    schema = CarbonTxtFile.model_json_schema()
+
+    rich.print(json.dumps(schema, indent=2))
+    return schema
 
 
 def configure_django(

--- a/src/carbon_txt/web/api.py
+++ b/src/carbon_txt/web/api.py
@@ -101,3 +101,18 @@ def validate_url(
 
     # Return errors if validation failed
     return {"success": False, "errors": result.errors()}
+
+
+@ninja_api.get(
+    "/json_schema/",
+    summary="Retrieve JSON Schema",
+    description="Get the JSON schema representation of carbon.txt file spec for validation",
+)
+def get_json_schema(request: HttpRequest) -> HttpResponse:
+    """
+    Endpoint to get the JSON schema for a carbon.txt file.
+    """
+    # Get the JSON schema for a carbon.txt file
+    schema = CarbonTxtFile.model_json_schema()
+
+    return schema

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import httpx
 import pytest
-import rich
 
 
 @pytest.mark.parametrize("url_suffix", ["", "/"])
@@ -12,7 +11,6 @@ def test_hitting_validate_endpoint_ok(
     api_url = f"{live_server.url}/api/validate/file{url_suffix}"
     data = {"text_contents": shorter_carbon_txt_string}
     res = httpx.post(api_url, json=data, follow_redirects=True)
-    rich.inspect(res)
 
     assert res.status_code == 200
 
@@ -27,7 +25,6 @@ def test_hitting_validate_endpoint_fail(live_server, url_suffix):
         api_url = f"{live_server.url}/api/validate/file{url_suffix}"
         data = {"text_contents": toml_file.read()}
         res = httpx.post(api_url, json=data, follow_redirects=True)
-        rich.inspect(res)
 
         assert res.status_code == 200
 
@@ -37,7 +34,6 @@ def test_hitting_validate_url_endpoint_ok(live_server, url_suffix):
     api_url = f"{live_server.url}/api/validate/url{url_suffix}"
     data = {"url": "https://aremythirdpartiesgreen.com/carbon.txt"}
     res = httpx.post(api_url, json=data, follow_redirects=True)
-    rich.inspect(res)
 
     assert res.status_code == 200
 
@@ -47,6 +43,12 @@ def test_hitting_validate_url_endpoint_fail(live_server, url_suffix):
     api_url = f"{live_server.url}/api/validate/url{url_suffix}"
     data = {"url": "https://aremythirdpartiesgreen.com/carbon.txt"}
     res = httpx.post(api_url, json=data, follow_redirects=True)
-    rich.inspect(res)
 
+    assert res.status_code == 200
+
+
+# TODO do we still need to run this with a full on external server?
+def test_hitting_fetch_json_schema(live_server):
+    api_url = f"{live_server.url}/api/json_schema"
+    res = httpx.get(api_url, follow_redirects=True)
     assert res.status_code == 200

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 from typer.testing import CliRunner
 
 from carbon_txt.cli import app
@@ -33,3 +35,16 @@ class TestCLI:
         )
         assert result.exit_code == 0
         assert "https://used-in-tests.carbontxt.org" in result.stdout
+
+    def test_schema(self):
+        """
+        Run our CLI to `carbontxt schema`, and confirm we
+        get back the expected JSON Schema representation of our domain objects
+        """
+
+        result = runner.invoke(app, ["schema"])
+        parsed_schema = json.loads(result.stdout)
+
+        assert result.exit_code == 0
+        assert "CarbonTxtFile" in parsed_schema.get("title")
+        assert "$defs" in parsed_schema.keys()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from typer.testing import CliRunner
 
 from carbon_txt.cli import app
 
-runner = CliRunner()
+runner = CliRunner(mix_stderr=False)
 
 
 class TestCLI:
@@ -46,5 +46,6 @@ class TestCLI:
         parsed_schema = json.loads(result.stdout)
 
         assert result.exit_code == 0
+        assert "JSON Schema for a carbon.txt file" in result.stderr
         assert "CarbonTxtFile" in parsed_schema.get("title")
         assert "$defs" in parsed_schema.keys()


### PR DESCRIPTION
This pull request introduces new functionality to generate and retrieve a JSON Schema representation of a `carbon.txt` file, along with some related changes to the CLI and API. It also includes test updates to validate the new functionality and removes some unnecessary imports and debug statements.

### New Functionality:
* Added a new CLI command to generate a JSON Schema representation of a `carbon.txt` file (`src/carbon_txt/cli.py`).
* Added a new API endpoint to retrieve the JSON Schema representation of a `carbon.txt` file (`src/carbon_txt/web/api.py`).

### Code Enhancements:
* Imported `json` and initialized `err_console` for error handling in CLI (`src/carbon_txt/cli.py`). [[1]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaR1-L4) [[2]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaR27-R28)

### Test Updates:
* Added a new test to validate the CLI command for generating the JSON Schema (`tests/test_cli.py`). [[1]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR1-R7) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR38-R51)
* Removed unnecessary `rich.inspect` statements from API tests (`tests/test_api_external.py`). [[1]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1L15) [[2]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1L30) [[3]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1L40) [[4]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1L50-R54)
* Added a new test to validate the API endpoint for retrieving the JSON Schema (`tests/test_api_external.py`).