### PR TITLE
Add initial http via lookup support

### DIFF
--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -9,23 +9,43 @@ class TestFinder:
 
         finder = FileFinder()
 
-        # Given a domain with
+        # Given a domain
+        domain = "used-in-tests.carbontxt.org"
 
         # When we pass a domain
-        result = finder.resolve_domain("used-in-tests.carbontxt.org")
+        result = finder.resolve_domain(domain)
 
         # We get back the URI of the carbon.txt file to lookup
-        assert result == "https://used-in-tests.carbontxt.org/carbon.txt"
+        assert result == f"https://{domain}/carbon.txt"
 
     def test_looking_up_uri_simple(self):
         """Looking up a domain with a carbon.txt file"""
 
         finder = FileFinder()
 
-        # Given a domain with
+        # Given a domain with carbon.txt extension
+        carbon_txt_url = "https://used-in-tests.carbontxt.org/carbon.txt"
 
         # When we pass a domain
-        result = finder.resolve_uri("https://used-in-tests.carbontxt.org/carbon.txt")
+        result = finder.resolve_uri(carbon_txt_url)
 
         # We get back the URI of the carbon.txt file to lookup
-        assert result == "https://used-in-tests.carbontxt.org/carbon.txt"
+        assert result == carbon_txt_url
+
+    def test_looking_up_uri_with_delegation_using_via(self):
+        """
+        Looking up a domain that has a 'via' http header should result
+        in us returning the URL in the via header, not the origina looked up URL
+        """
+
+        finder = FileFinder()
+
+        # Given our origina domain with
+        hosted_domain = "https://hosted.carbontxt.org/carbon.txt"
+        via_domain = "https://managed-service.carbontxt.org/carbon.txt"
+
+        # When we pass a domain
+        result = finder.resolve_uri(hosted_domain)
+
+        # We get back the URI of the carbon.txt file to lookup
+        assert result == via_domain


### PR DESCRIPTION
This pull request introduces a new feature to handle 'via' HTTP headers in the `FileFinder` class and updates the corresponding tests. The changes include adding a method to check for 'via' headers, modifying the URI resolution logic to use this method, and adding new test cases to verify the functionality.

### New Feature: Handling 'via' HTTP Headers

* [`src/carbon_txt/finders.py`](diffhunk://#diff-b4b173d63a512a58ae26461037b3a9f992f923eb31834e9de9db407e098f4e74R94-R113): Added a new method `_check_for_via_delegation` to check for 'via' headers in the HTTP response and return the URL specified in the header if present.
* [`src/carbon_txt/finders.py`](diffhunk://#diff-b4b173d63a512a58ae26461037b3a9f992f923eb31834e9de9db407e098f4e74L103-R143): Updated the `resolve_uri` method to use `_check_for_via_delegation` for handling 'via' headers and to raise an exception if the HTTP request fails.

### Test Updates

* [`tests/test_finders.py`](diffhunk://#diff-dac7ebf401f9f9038c95d100c1970755a3254b04b160e04bfc876038629b873bL12-R51): Modified existing test cases to use variables for domain and URL strings for better readability.
* [`tests/test_finders.py`](diffhunk://#diff-dac7ebf401f9f9038c95d100c1970755a3254b04b160e04bfc876038629b873bL12-R51): Added a new test case `test_looking_up_uri_with_delegation_using_via` to verify that the `resolve_uri` method correctly follows the URL specified in the 'via' header.