### PR TITLE
Introduce use of app-specific exceptions

### DIFF
--- a/src/carbon_txt/cli.py
+++ b/src/carbon_txt/cli.py
@@ -10,7 +10,7 @@ import typer
 from django.core.management import execute_from_command_line
 
 from . import finders, parsers_toml
-from .exceptions import InsecureKeyException
+from . import exceptions
 from .schemas import CarbonTxtFile
 
 logger = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ def validate_domain(domain: str):
         rich.print(f"Carbon.txt file found at {result}.\n")
     else:
         rich.print(f"No valid carbon.txt file found on {domain}.\n")
-        return 1
+        typer.Exit(code=1)
 
     # fetch and parse file
     content = parser.get_carbon_txt_file(result)
@@ -62,11 +62,11 @@ def validate_domain(domain: str):
     if isinstance(validation_results, CarbonTxtFile):
         _log_validation_results(success=True)
         _log_validated_carbon_txt_object(validation_results)
-        return 0
+        typer.Exit(code=0)
     else:
         _log_validation_results(success=False)
         _log_validated_carbon_txt_object(validation_results)
-        return 1
+        typer.Exit(code=1)
 
 
 @validate_app.command("file")
@@ -80,30 +80,43 @@ def validate_file(
     else:
         try:
             result = file_finder.resolve_uri(file_path)
+            logger.info("Carbon.txt file found at {result}.\n")
+            content = parser.get_carbon_txt_file(result)
+            logger.info("Carbon.txt file parsed .\n")
+            parsed_result = parser.parse_toml(content)
+
+        # the file path is local, but we can't access it
         except FileNotFoundError:
             full_file_path = Path(file_path).absolute()
             rich.print(f"No valid carbon.txt file found at {full_file_path}. \n")
-            return 1
+            raise typer.Exit(code=1)
 
-        if result:
-            rich.print(f"Carbon.txt file found at {result}.\n")
-            content = parser.get_carbon_txt_file(result)
-        else:
-            full_file_path = Path(file_path).absolute()
-            rich.print(f"No valid carbon.txt file found at {full_file_path}. \n")
-            return 1
+        # the file path is remote, and we can't access it
+        except exceptions.UnreachableCarbonTxtFile as e:
+            logger.error(f"Error: {e}")
+            raise typer.Exit(code=1)
 
-    parsed_result = parser.parse_toml(content)
+        # the file path is reachable, and but it's not valid TOML
+        except exceptions.NotParseableTOML as e:
+            rich.print(
+                f"A carbon.txt file was found at {file_path}: but it wasn't parseable TOML. Error was: {e}"
+            )
+            raise typer.Exit(code=1)
+
+        except Exception as e:
+            rich.print(f"An unexpected error occurred: {e}")
+            raise typer.Exit(code=1)
+
     validation_results = parser.validate_as_carbon_txt(parsed_result)
 
     if isinstance(validation_results, CarbonTxtFile):
         _log_validation_results(success=True)
         _log_validated_carbon_txt_object(validation_results)
-        return 0
+        return typer.Exit(code=0)
     else:
         _log_validation_results(success=False)
         _log_validated_carbon_txt_object(validation_results)
-        return 1
+        return typer.Exit(code=0)
 
 
 @app.command()
@@ -119,7 +132,7 @@ def schema():
         rich.print(json.dumps(schema, indent=2))
     else:
         print(json.dumps(schema, indent=2))
-    return 0
+    typer.Exit(code=0)
 
 
 def configure_django(
@@ -173,12 +186,12 @@ def serve(
             os.system("granian --interface wsgi carbon_txt.web.config.wsgi:application")
         else:
             execute_from_command_line(["manage.py", "runserver", f"{host}:{port}"])
-    except InsecureKeyException as e:
+    except exceptions.InsecureKeyException as e:
         rich.print(f"{e}")
         rich.print(
             "For more, see the docs at https://carbon-txt-validator.readthedocs.io/en/latest/deployment.html"
         )
-        sys.exit(1)
+        typer.Exit(code=1)
     # anything unexpected we provide a clear path to raising an issue to fix it
     except Exception as e:
         rich.print(f"An error occurred: {e}")
@@ -189,7 +202,7 @@ def serve(
                 "with steps to reproduce this error"
             )
         )
-        sys.exit(1)
+        typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/src/carbon_txt/cli.py
+++ b/src/carbon_txt/cli.py
@@ -77,13 +77,11 @@ def validate_file(
 ):
     if file_path == "-":
         content = typer.get_text_stream("stdin").read()
+        parsed_result = parser.parse_toml(content)
     else:
         try:
             result = file_finder.resolve_uri(file_path)
-            logger.info("Carbon.txt file found at {result}.\n")
-            content = parser.get_carbon_txt_file(result)
-            logger.info("Carbon.txt file parsed .\n")
-            parsed_result = parser.parse_toml(content)
+            parsed_result = parser.fetch_parsed_carbon_txt_file(result)
 
         # the file path is local, but we can't access it
         except FileNotFoundError:

--- a/src/carbon_txt/exceptions.py
+++ b/src/carbon_txt/exceptions.py
@@ -1,4 +1,24 @@
 class InsecureKeyException(Exception):
-    """Raised when the default SECRET_KEY is used in a production django server environment"""
+    """
+    Raised when the default SECRET_KEY is used in a
+    production django server environment
+    """
+
+    pass
+
+
+class UnreachableCarbonTxtFile(Exception):
+    """
+    Raised when we can't reach the carbon.txt file
+    """
+
+    pass
+
+
+class NotParseableTOML(Exception):
+    """
+    Raised when we have a response at a the given carbon txt
+    URL, but it is not parsable TOML file
+    """
 
     pass

--- a/src/carbon_txt/parsers_toml.py
+++ b/src/carbon_txt/parsers_toml.py
@@ -32,13 +32,15 @@ class CarbonTxtParser:
         if pathlib.Path(str).exists():
             return pathlib.Path(str).read_text()
 
-    def fetch_pared_carbon_txt_file(self, uri: str) -> dict:
+    def fetch_parsed_carbon_txt_file(self, uri: str) -> dict:
         """
         Accept a URI and return a parsed TOML object.
         """
         try:
             carbon_txt = self.get_carbon_txt_file(uri)
+            logger.info("Carbon.txt file found at {result}.\n")
             parsed = self.parse_toml(carbon_txt)
+            logger.info("Carbon.txt file parsed .\n")
             return parsed
         except toml.TOMLDecodeError as e:
             raise exceptions.NotParseableTOML(e)

--- a/src/carbon_txt/parsers_toml.py
+++ b/src/carbon_txt/parsers_toml.py
@@ -3,6 +3,8 @@ from . import schemas
 import httpx
 import pathlib
 
+from . import exceptions
+
 
 import logging
 
@@ -30,13 +32,27 @@ class CarbonTxtParser:
         if pathlib.Path(str).exists():
             return pathlib.Path(str).read_text()
 
+    def fetch_pared_carbon_txt_file(self, uri: str) -> dict:
+        """
+        Accept a URI and return a parsed TOML object.
+        """
+        try:
+            carbon_txt = self.get_carbon_txt_file(uri)
+            parsed = self.parse_toml(carbon_txt)
+            return parsed
+        except toml.TOMLDecodeError as e:
+            raise exceptions.NotParseableTOML(e)
+
     def parse_toml(self, str) -> dict:
         """
-        Accept a string of TOML and return a CarbonTxtFile
-        object
+        Accept a string of TOML and return a dict representing the
+        keys and values going into a CarbonTxtFile object.
         """
-        parsed = toml.loads(str)
-        return parsed
+        try:
+            parsed = toml.loads(str)
+            return parsed
+        except toml.TOMLDecodeError as e:
+            raise exceptions.NotParseableTOML(e)
 
     def validate_as_carbon_txt(self, parsed) -> schemas.CarbonTxtFile:
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,17 @@ class TestCLI:
         assert result.exit_code == 0
         assert "https://used-in-tests.carbontxt.org" in result.stdout
 
+    def test_lookup_missing_file(self):
+        """
+        Run our CLI to `carbontxt validate file https://some-domain.com/carbon.txt`,
+        """
+
+        # Update to a domain we know will not ever have a carbon.txt file
+        result = runner.invoke(
+            app, ["validate", "file", "https://www.thegreenwebfoundation.org"]
+        )
+        assert result.exit_code == 1
+
     def test_schema(self):
         """
         Run our CLI to `carbontxt schema`, and confirm we


### PR DESCRIPTION
This pull request includes several changes to improve error handling and logging in the `carbon_txt` CLI application. The most important changes involve replacing `sys.exit` calls with `typer.Exit` for better integration with Typer, enhancing exception handling, and adding new tests for missing files.

### Error Handling Improvements:
* Replaced `sys.exit` calls with `typer.Exit` in various functions for better integration with Typer. [[1]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaL54-R54) [[2]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaL65-R69) [[3]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaR83-R119) [[4]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaL122-R135) [[5]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaL176-R194) [[6]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaL192-R205)
* Enhanced exception handling in `validate_file` to catch specific exceptions (`FileNotFoundError`, `UnreachableCarbonTxtFile`, `NotParseableTOML`) and log appropriate messages.

### Logging Enhancements:
* Added logging statements in `validate_file` to log the discovery and parsing of `carbon.txt` files.

### Exception Handling Enhancements:
* Introduced new exceptions (`UnreachableCarbonTxtFile`, `NotParseableTOML`) in `exceptions.py` to handle specific error cases.
* Updated `finders.py` and `parsers_toml.py` to use the new exceptions for better error reporting. [[1]](diffhunk://#diff-b4b173d63a512a58ae26461037b3a9f992f923eb31834e9de9db407e098f4e74R9-R10) [[2]](diffhunk://#diff-b4b173d63a512a58ae26461037b3a9f992f923eb31834e9de9db407e098f4e74R134-R140) [[3]](diffhunk://#diff-047bbadaeedbdc3b3061daa6ee4c06974ecd2d6c84a58d27cc9ba8db87ebb9c1R6-R7) [[4]](diffhunk://#diff-047bbadaeedbdc3b3061daa6ee4c06974ecd2d6c84a58d27cc9ba8db87ebb9c1R35-R55)

### Testing Improvements:
* Added a new test in `test_cli.py` to check the behavior when a `carbon.txt` file is missing.