### PR TITLE
Updated changelog add first pass at tag release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Publish Python Package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release_to_pypi:
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+        # https://github.com/marketplace/actions/setup-just
+      - uses: extractions/setup-just@v2
+        name: install just
+
+        # https://docs.astral.sh/uv/guides/integration/github/
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.5.0"
+          enable-cache: true
+
+      - name: Use Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.1.12"
+
+      - name: Install tooling for managing dependencies
+        run: uv sync
+
+      - name: Extract project version from pyproject.toml
+        id: extract_version
+        run: |
+          VERSION=$(grep -Po '(?<=version = ")[^"]*' pyproject.toml)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Check if tag matches version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "Tag ($TAG) does not match version ($VERSION) in pyproject.toml"
+            exit 1
+          fi
+
+      - name: Built package
+        run: just build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ Fixed, Changed, Added, Removed, Fixed, Security
 
 ## Unreleased
 
+## [0.0.8]
 
+### Changed
+
+- Switch to using more detailed exceptions
+
+### Added
 - Add support for generating JSON Schema representation with CLI and API
 - Add support for using Sentry to track exceptions, performance and so on.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,16 @@ Fixed, Changed, Added, Removed, Fixed, Security
 - Switch to using more detailed exceptions
 
 ### Added
+
 - Add support for generating JSON Schema representation with CLI and API
 - Add support for using Sentry to track exceptions, performance and so on.
+- Add github action for automated publishing of releases to Pypi
+
+### Fixed
+
+- Respect the provided `port` and `host` values with `carbon-txt serve` [#27](https://github.com/thegreenwebfoundation/carbon-txt-validator/issues/27)
+
+
 
 ## [0.0.7]
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 ## How carbon.txt is designed.
 
 ```{admonition} TODO
-This page needs variants of the diagrams from on [our initiial report](https://www.thegreenwebfoundation.org/publications/carbon-txt-energy-efficiency-briefing/) to be added
+This page needs variants of the diagrams from on [our initial report](https://www.thegreenwebfoundation.org/publications/carbon-txt-energy-efficiency-briefing/) to be added
 ```
 
 The carbon.txt validator is split into a series of components, with clear

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,3 +49,18 @@ In our case we could push like so:
 ```
 git push origin v1.2.3
 ```
+
+#### Deleting a tag
+
+Tags are tied to specific commits, not branches. So if you have created a tag for a release _but have not pushed it_, you can delete the tag, locally with:
+
+```
+git tag -d v1.2.3
+```
+
+You can then re-tag the relevant commit, ready to push and publish:
+
+```
+git tag v1.2.3
+git push origin v1.2.3
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,51 @@
+# Contributing to the carbon-txt validator project
+
+The Carbon-txt validator is an open source project and contributions are welcomed.
+
+Our [issue tracker is on Github](https://github.com/thegreenwebfoundation/carbon-txt-validator/issues), and maintain a high level roadmap of coming releases as milestones.
+
+### Getting set up
+
+Follow the instructions in [installation](installation.md) to get set up if you are on a local machine.
+
+If you prefer to use remote workspace - see [this issue for setting up a github Codespace, (contributions welcome!)](https://github.com/thegreenwebfoundation/carbon-txt-validator/issues/29)
+
+
+### Publishing a release
+
+To publish a release to PyPi, on the branch you want to release, you need to create a tag matching the version number in `pyproject.toml`, and then push that tag to the main repository.
+
+If you have origin set to this repository like so:
+
+```
+# output from git remote -v
+
+origin  git@github.com:thegreenwebfoundation/carbon-txt-validator.git (fetch)
+origin  git@github.com:thegreenwebfoundation/carbon-txt-validator.git (push)
+```
+
+And you wanted to push tag 1.2.3, first check that your `pyproject.toml` has that release numbers:
+
+```
+# pyproject.toml
+
+[project]
+name = "carbon-txt"
+version = "0.0.8rc1"
+```
+
+Then make a git tag, making sure you have the `v` prefix for the version number:
+
+```
+git tag v1.2.3
+```
+
+There is a Github action set up in `.github/workflows/release.yml` that listens for new tags being pushed to the main repo, and then pushes the arelease to PyPi using the [Trusted publisher](https://docs.pypi.org/trusted-publishers/) process.
+
+To push a git tag, use the tag name when pushing to the origin repository.
+
+In our case we could push like so:
+
+```
+git push origin v1.2.3
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,4 +9,5 @@ but it should at least contain the root `toctree` directive. -->
 installation
 architecture
 deployment
+contributing
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,9 @@
+# Usage
+
+```{admonition} TODO
+Add short description for main CLI commands
+```
+
+## Using the carbon-txt validator on the commandline
+
+## Using the carbon-txt validator as a server

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ default:
 
 # invoke the cli, as if you were running `carbon-txt` after downloading the package
 run-cli *options:
-  uv run carbon-txt
+  uv run carbon-txt {{ options }}
 
 # show the environment variables available
 env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carbon-txt"
-version = "0.0.7"
+version = "0.0.8rc1"
 description = "A command line tool containing a validator for carbon.txt files, by the Green Web Foundation"
 authors = [
     { name = "Chris Adams" },

--- a/src/carbon_txt/cli.py
+++ b/src/carbon_txt/cli.py
@@ -181,7 +181,12 @@ def serve(
             rich.print("Running with Granian server")
             rich.print("\n ----------------\n")
             # Run Granian instead of Django development server
-            os.system("granian --interface wsgi carbon_txt.web.config.wsgi:application")
+            os.system(
+                (
+                    "granian --interface wsgi carbon_txt.web.config.wsgi:application"
+                    "--host {host} --port {port}"
+                )
+            )
         else:
             execute_from_command_line(["manage.py", "runserver", f"{host}:{port}"])
     except exceptions.InsecureKeyException as e:

--- a/uv.lock
+++ b/uv.lock
@@ -89,7 +89,7 @@ wheels = [
 
 [[package]]
 name = "carbon-txt"
-version = "0.0.7"
+version = "0.0.8rc1"
 source = { editable = "." }
 dependencies = [
     { name = "django-cors-headers" },


### PR DESCRIPTION
This pull request includes several changes to automate the release process, update the project version, and improve the command-line interface. The most important changes include adding a GitHub Action for automated publishing, updating the version in `pyproject.toml`, and enhancing the `serve` command to respect custom host and port values.

### Automation and CI/CD:

* Added a GitHub Action workflow for automated publishing of the Python package to PyPI upon tagging a release. This includes steps for setting up dependencies, checking version consistency, and publishing the package. (`.github/workflows/release.yml`)

### Versioning:

* Updated the project version to `0.0.8rc1` in `pyproject.toml`. (`pyproject.toml`)

### Changelog:

* Updated `CHANGELOG.md` to include changes for version `0.0.8`, such as switching to more detailed exceptions, adding support for JSON Schema generation, Sentry integration, and the new GitHub Action for automated publishing. (`CHANGELOG.md`)

### Command-line Interface:

* Modified the `serve` command to respect the provided `host` and `port` values, improving flexibility for running the server. (`src/carbon_txt/cli.py`)
* Updated the `run-cli` command in `justfile` to pass additional options, enhancing its usability. (`justfile`)