### PR TITLE
Fix api response for via lookup - resolves #30

### DIFF
--- a/src/carbon_txt/web/api.py
+++ b/src/carbon_txt/web/api.py
@@ -5,6 +5,13 @@ from carbon_txt.parsers_toml import CarbonTxtParser
 from carbon_txt.schemas import CarbonTxtFile
 from pydantic import HttpUrl
 
+from .. import finders
+from .. import exceptions
+import logging
+
+file_finder = finders.FileFinder()
+logger = logging.getLogger(__name__)
+
 # Initialize the NinjaAPI with OpenAPI documentation details
 ninja_api = NinjaAPI(
     openapi_extra={
@@ -87,16 +94,23 @@ def validate_url(
     parser = CarbonTxtParser()
 
     # Fetch and parse the contents of the URL
-
     url_string = str(carbon_txt_url_data.url)
-    carbon_txt_contents = parser.get_carbon_txt_file(url_string)
-    parsed = parser.parse_toml(carbon_txt_contents)
+    try:
+        result = file_finder.resolve_uri(url_string)
+        parsed_result = parser.fetch_parsed_carbon_txt_file(result)
+    except exceptions.UnreachableCarbonTxtFile as e:
+        logger.error(f"Error: {e}")
+        return {"success": False, "errors": [e]}
+    except exceptions.NotParseableTOML as e:
+        logger.warning(
+            f"A carbon.txt file was found at {url_string}: but it wasn't parseable TOML. Error was: {e}"
+        )
+        return {"success": False, "errors": [e]}
 
     # Validate the parsed contents as a carbon.txt file
-    result = parser.validate_as_carbon_txt(parsed)
-
+    validation_results = parser.validate_as_carbon_txt(parsed_result)
     # Check if the result is a valid CarbonTxtFile instance
-    if isinstance(result, CarbonTxtFile):
+    if isinstance(validation_results, CarbonTxtFile):
         return {"success": True, "data": result}
 
     # Return errors if validation failed

--- a/src/carbon_txt/web/api.py
+++ b/src/carbon_txt/web/api.py
@@ -106,15 +106,18 @@ def validate_url(
             f"A carbon.txt file was found at {url_string}: but it wasn't parseable TOML. Error was: {e}"
         )
         return {"success": False, "errors": [e]}
+    except Exception as e:
+        logger.warning(f"unexpected error: {e}")
+        return {"success": False, "errors": [e]}
 
     # Validate the parsed contents as a carbon.txt file
     validation_results = parser.validate_as_carbon_txt(parsed_result)
     # Check if the result is a valid CarbonTxtFile instance
     if isinstance(validation_results, CarbonTxtFile):
-        return {"success": True, "data": result}
+        return {"success": True, "data": validation_results}
 
     # Return errors if validation failed
-    return {"success": False, "errors": result.errors()}
+    return {"success": False, "errors": validation_results.errors()}
 
 
 @ninja_api.get(

--- a/tests/api_external.py
+++ b/tests/api_external.py
@@ -17,10 +17,11 @@ def check_carbon_txt_contents():
 
 
 def check_carbon_txt_url():
-    api_url = "http://127.0.0.1:8000/api/validate/url/"
-    data = {"url": "https://aremythirdpartiesgreen.com/carbon.txt"}
+    api_url = "http://127.0.0.1:9000/api/validate/url/"
+    data = {"url": "https://hosted.carbontxt.org/carbon.txt"}
     res = httpx.post(api_url, json=data, follow_redirects=True)
     rich.print(res)
+    breakpoint()
     pretty.pprint(res.json())
 
 

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 import httpx
 import pytest
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("url_suffix", ["", "/"])
@@ -48,11 +51,18 @@ def test_hitting_validate_url_endpoint_fail(live_server, url_suffix):
 
 
 def test_hitting_validate_url_endpoint_with_via_delegation(live_server):
+    """
+    When we have a carbon.txt url that is delegating to a another server
+    using the http 'via' header, does it follow the delegation and return the
+    correct response?
+    """
     api_url = f"{live_server.url}/api/validate/url/"
     data = {"url": "https://hosted.carbontxt.org/carbon.txt"}
     res = httpx.post(api_url, json=data, follow_redirects=True)
 
     assert res.status_code == 200
+    actual_provider_domain = res.json()["data"]["org"]["credentials"][0]["domain"]
+    assert actual_provider_domain == "managed-service.carbontxt.org"
 
 
 # TODO do we still need to run this with a full on external server?

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -47,6 +47,14 @@ def test_hitting_validate_url_endpoint_fail(live_server, url_suffix):
     assert res.status_code == 200
 
 
+def test_hitting_validate_url_endpoint_with_via_delegation(live_server):
+    api_url = f"{live_server.url}/api/validate/url/"
+    data = {"url": "https://hosted.carbontxt.org/carbon.txt"}
+    res = httpx.post(api_url, json=data, follow_redirects=True)
+
+    assert res.status_code == 200
+
+
 # TODO do we still need to run this with a full on external server?
 def test_hitting_fetch_json_schema(live_server):
     api_url = f"{live_server.url}/api/json_schema"


### PR DESCRIPTION
This pull request includes several significant changes to the `src/carbon_txt/web/api.py` and related test files to improve error handling, logging, and test coverage.

### Error Handling and Logging Improvements:

* [`src/carbon_txt/web/api.py`](diffhunk://#diff-a7d46725d3e2c1b29c33a4ec373597f2fa5ca5faf2ba88f30fb82d47d4b2acbcR8-R14): Added imports for `finders`, `exceptions`, and `logging`. Introduced a `file_finder` instance and a `logger` instance to handle file resolution and logging respectively. Updated the `validate_url` function to include comprehensive error handling using `try`/`except` blocks and logging for various exceptions. [[1]](diffhunk://#diff-a7d46725d3e2c1b29c33a4ec373597f2fa5ca5faf2ba88f30fb82d47d4b2acbcR8-R14) [[2]](diffhunk://#diff-a7d46725d3e2c1b29c33a4ec373597f2fa5ca5faf2ba88f30fb82d47d4b2acbcL90-R120)

### Test Updates:

* [`tests/api_external.py`](diffhunk://#diff-7c47bd5cd8c82445587449ff54e9c7c7bb4f4c3d2f1ec47362192701bb63c118L20-R24): Updated the `check_carbon_txt_url` function to use a new API URL and data URL, and added a breakpoint for debugging.
* [`tests/test_api_external.py`](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1R5-R7): Added a `logger` instance for logging purposes. Introduced a new test function `test_hitting_validate_url_endpoint_with_via_delegation` to verify the behavior of the validation endpoint when handling URL delegation using the HTTP 'via' header. [[1]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1R5-R7) [[2]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1R53-R67)