### PR TITLE
Fix #39 - Consisent error responses from API

### DIFF
--- a/src/carbon_txt/web/api.py
+++ b/src/carbon_txt/web/api.py
@@ -70,7 +70,7 @@ def validate_contents(
     else:
         return {
             "success": False,
-            "data": validation_results.exceptions,
+            "errors": validation_results.exceptions,
             "logs": validation_results.logs,
         }  # type: ignore
 


### PR DESCRIPTION
This change returns consistent API responses for the `validate/url` and `validate/file` endpoints.

Success scenario:
`success`, `data`, `logs`

Error scenario:
`success`, `errors`, `logs`