### PR TITLE
Add access logging for the bundled granian server

### DIFF
--- a/src/carbon_txt/cli.py
+++ b/src/carbon_txt/cli.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import subprocess
 import sys
 
 import django
@@ -149,13 +150,20 @@ def serve(
             rich.print("Running with Granian server")
             rich.print("\n ----------------\n")
             # Run Granian instead of Django development server
-            os.system(
-                (
-                    "granian --interface wsgi "
-                    f"--host {host} --port {port} "
-                    "carbon_txt.web.config.wsgi:application"
-                )
-            )
+
+            cmd_args = [
+                "granian",
+                "--interface",
+                "wsgi",
+                "--host",
+                str(host),
+                "--port",
+                str(port),
+                # without the access log flag we see no requests in the logs
+                "--access-log",
+                "carbon_txt.web.config.wsgi:application",
+            ]
+            subprocess.run(cmd_args)
         else:
             execute_from_command_line(["manage.py", "runserver", f"{host}:{port}"])
     except exceptions.InsecureKeyException as e:


### PR DESCRIPTION
This pull request includes changes to improve the handling of subprocesses in the `src/carbon_txt/cli.py` file. The most important changes include switching from `os.system` to `subprocess.run` for executing the Granian server command and adding the necessary import for the `subprocess` module.

Improvements to subprocess handling:

* [`src/carbon_txt/cli.py`](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaR4): Added the `subprocess` import to handle subprocess execution more securely and robustly.
* [`src/carbon_txt/cli.py`](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaL152-R166): Replaced the `os.system` call with `subprocess.run` for running the Granian server, allowing for better argument handling and improved security.This replaces the the use of os.system with the
idiomatic subprocess.run