### PR TITLE
Add tests for activating plugins via command line flags and django settings

### DIFF
--- a/src/carbon_txt/validators.py
+++ b/src/carbon_txt/validators.py
@@ -81,7 +81,8 @@ class CarbonTxtValidator:
             # we need to append all the logs to the event log so we can show them
             # in the API requests
             for item in result_sub_list:
-                if hook_logs := item.pop("logs"):
+                if item.get("logs"):
+                    hook_logs = item.pop("logs")
                     self.event_log.extend(hook_logs)
 
         result_list.extend(result_sub_list)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,3 +62,24 @@ class TestCLI:
         assert "JSON Schema for a carbon.txt file" in result.stderr
         assert "CarbonTxtFile" in parsed_schema.get("title")
         assert "$defs" in parsed_schema.keys()
+
+    def test_lookup_domain_with_test_plugin(self):
+        """
+        Test that we can run the CLI with a custom plugin directory
+        """
+
+        result = runner.invoke(
+            app,
+            [
+                "validate",
+                "domain",
+                "used-in-tests.carbontxt.org",
+                "--plugins-dir",
+                "tests/test_plugins",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "used-in-tests.carbontxt.org" in result.stdout
+
+        # check that we see output from the test plugin
+        assert "Test Plugin:" in result.stdout

--- a/tests/test_plugins/process_document.py
+++ b/tests/test_plugins/process_document.py
@@ -1,0 +1,36 @@
+from carbon_txt.hookspecs import hookimpl  # type: ignore
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def log_safely(log_message: str, logs: Optional[list], level=logging.INFO):
+    """
+    Log a message, and append it to a list of logs
+    """
+    logger.log(level, log_message)
+    if logs is not None:
+        logs.append(log_message)
+
+
+@hookimpl
+def process_document(document, parsed_carbon_txt_file, logs):
+    # This is just a sample function to demonstrate
+    # returning the result of ANY processing of the document
+
+    log_safely(
+        f"Test Plugin: Processing supporting document: {document.url}", logs=logs
+    )
+    document_processing_results = document.__dict__
+    carbon_test_file_size = parsed_carbon_txt_file.__dict__
+
+    return {
+        document.url: [
+            "TEST PLUGIN RETURN VALUES",
+            document_processing_results,
+            carbon_test_file_size,
+        ],
+        "logs": logs,
+    }


### PR DESCRIPTION
This PR introduces tests to demonstrate our plugins working, both on the command line, and via the django setting environment variables (this is the mechanism used to propogate the command line flags to the django app, because we don't always run `django.setup()` for every CLI command, so can't rely on just having the plugin config stored in the django config file.


Auto generated summary below:
---

This pull request includes several changes to improve the handling and testing of plugins in the `carbon_txt` project. The most important changes include updating the document processing logic, adding new test fixtures and test cases, and implementing a sample plugin for demonstration purposes.

### Improvements to document processing:

* [`src/carbon_txt/validators.py`](diffhunk://#diff-ee4638d5f5c485cd75d48d52d7f2d32e24512f6ee6d1455711fa44f87d0b7a09L84-R85): Modified the `_append_document_processing` method to ensure logs are correctly appended to the event log.

### Enhancements to testing:

* [`tests/test_api_external.py`](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1R10-R14): Added a new fixture `settings_with_plugin_dir_set` and a new test `test_hitting_validate_with_plugins_dir_set` to verify the behavior with a custom plugins directory. [[1]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1R10-R14) [[2]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1R99-R128)
* [`tests/test_cli.py`](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR65-R85): Added a new test `test_lookup_domain_with_test_plugin` to ensure the CLI can run with a custom plugin directory and verify the output from the test plugin.

### Implementation of a sample plugin:

* [`tests/test_plugins/process_document.py`](diffhunk://#diff-963b732f23b4ebf1df43850348303a689fa8e6b8b966f9e34d54513d0c7b91eaR1-R36): Implemented a sample plugin that demonstrates how to process a document and log messages safely.