### PR TITLE
Add test for activated internal csrd plugin

### DIFF
--- a/src/carbon_txt/process_document.py
+++ b/src/carbon_txt/process_document.py
@@ -1,0 +1,62 @@
+from .hookspecs import hookimpl
+from .schemas import CarbonTxtFile, Credential
+from .processors import CSRDProcessor
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def log_safely(log_message: str, logs: Optional[list], level=logging.INFO):
+    """
+    Log a message, and append it to a list of logs
+    """
+    logger.log(level, log_message)
+    if logs is not None:
+        logs.append(log_message)
+
+
+@hookimpl
+def process_document(
+    document: Credential,
+    parsed_carbon_txt_file: Optional[CarbonTxtFile],
+    logs: Optional[list],
+):
+    """
+    Listen for documents linked in the carbon.txt file that are ixbrl CSRD reports,
+    and use Arelle to parse them for selected datapoints
+    """
+    log_safely(
+        f"{__name__}: Processing supporting document: {document.url} for {document.domain}",
+        logs=logs,
+    )
+
+    if document.doctype == "csrd-report":
+        log_safely(
+            f"{__name__}: CSRD Report found. Processing report with Arelle: {document}",
+            logs=logs,
+        )
+
+        try:
+            processor = CSRDProcessor(document.url)
+
+            chosen_datapoints = [
+                value.replace("esrs:", "")
+                for value in CSRDProcessor.esrs_datapoints.keys()
+            ]
+
+            results = processor.get_esrs_datapoint_values(chosen_datapoints)
+
+            return {document.url: results, "logs": logs}
+        except Exception as e:
+            log_safely(
+                f"Error occurred when loading report at {document.url}: {e}", logs=logs
+            )
+
+    else:
+        log_safely(
+            f"{__name__}: Document type {document.doctype} seen. Doing nothing",
+            logs=logs,
+        )
+
+    return {"logs": logs}

--- a/src/carbon_txt/schemas.py
+++ b/src/carbon_txt/schemas.py
@@ -23,7 +23,12 @@ class Credential(BaseModel):
 
     domain: Optional[str] = None
     doctype: Literal[
-        "web-page", "annual-report", "sustainability-page", "certificate", "other"
+        "web-page",
+        "annual-report",
+        "sustainability-page",
+        "certificate",
+        "csrd-report",
+        "other",
     ]
     url: str
 

--- a/src/carbon_txt/web/config/settings/base.py
+++ b/src/carbon_txt/web/config/settings/base.py
@@ -18,6 +18,7 @@ import environ
 import sentry_sdk
 
 from carbon_txt.exceptions import InsecureKeyException
+from carbon_txt.plugins import DEFAULT_PLUGINS as DEFAULT_CARBON_TXT_PLUGINS
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,8 @@ env = environ.Env(
     SENTRY_TRACE_SAMPLE_RATE=(float, 0),
     SENTRY_PROFILE_SAMPLE_RATE=(float, 0),
     CARBON_TXT_PLUGINS_DIR=(str, None),
+    ACTIVE_CARBON_TXT_PLUGINS=(list, []),
+    DEFAULT_CARBON_TXT_PLUGINS=(list, DEFAULT_CARBON_TXT_PLUGINS),
 )
 
 # fetch environment variables from .env file
@@ -181,4 +184,5 @@ if env("SENTRY_DSN"):
         profiles_sample_rate=env("SENTRY_PROFILE_SAMPLE_RATE"),
     )
 
+ACTIVE_CARBON_TXT_PLUGINS = env("ACTIVE_CARBON_TXT_PLUGINS")
 CARBON_TXT_PLUGINS_DIR = env("CARBON_TXT_PLUGINS_DIR")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,3 +55,18 @@ def multi_domain_carbon_txt_string():
         carbon_txt_string = carb_file.read()
 
     return carbon_txt_string
+
+
+def minimal_carbon_txt_org_with_csrd_file():
+    """
+    A sample minimal carbon.txt file, assuming no upstream, and
+    linking to a CSRD report containing renewables data
+    """
+    return """
+        [upstream]
+        providers = []
+        [org]
+        credentials = [
+            { domain='used-in-tests.carbontxt.org', doctype = 'csrd-report', url = 'https://used-in-tests.carbontxt.org/esrs-e1-efrag-2026-12-31-en.xhtml'}
+        ]
+    """  # noqa

--- a/tests/test_internal_plugins.py
+++ b/tests/test_internal_plugins.py
@@ -1,0 +1,49 @@
+from carbon_txt import validators  # type: ignore
+from django.conf import settings
+import pytest
+
+import rich
+
+
+@pytest.fixture()
+def settings_with_active_csrd_plugin_(settings):
+    settings.ACTIVE_CARBON_TXT_PLUGINS = ("carbon_txt.process_document",)
+
+
+class TestCarbonTxtValidatorWithCSRDPlugin:
+    def test_validate_carbon_txt_file_with_csrd_report(
+        self, settings_with_active_csrd_plugin_
+    ):
+        """
+        Test that we can validate a valid CSRD report, and that it passes validation.
+        """
+
+        validator = validators.CarbonTxtValidator(
+            active_plugins=settings.ACTIVE_CARBON_TXT_PLUGINS
+        )
+
+        res = validator.validate_url(
+            "https://used-in-tests.carbontxt.org/carbon-txt-with-csrd-and-renewables.txt"
+        )
+        # TODO: Arelle is very slow when parsing an CSRD report for the first time.
+        # look into caching
+        rich.print(res.document_results)
+
+        csrd_plugin_parse_results = res.document_results[0]
+        csrd_report_url = (
+            "https://used-in-tests.carbontxt.org/esrs-e1-efrag-2026-12-31-en.xhtml"
+        )
+        for key in [
+            "PercentageOfRenewableSourcesInTotalEnergyConsumption",
+            "PercentageOfEnergyConsumptionFromNuclearSourcesInTotalEnergyConsumption",
+            "EnergyConsumptionRelatedToOwnOperations",
+            "EnergyConsumptionFromFossilSources",
+            "EnergyConsumptionFromNuclearSources",
+            "EnergyConsumptionFromRenewableSources",
+            "ConsumptionOfPurchasedOrAcquiredElectricityHeatSteamAndCoolingFromRenewableSources",
+            "ConsumptionOfSelfgeneratedNonfuelRenewableEnergy",
+        ]:
+            assert key in csrd_plugin_parse_results[csrd_report_url].keys()
+
+        assert res.result
+        assert not res.exceptions


### PR DESCRIPTION
This PR introduces the first CSRD plugin where we look for the data points in a sample report detailed in #44.

We now support a new environment variable that allow us to run the validator with a CSRD parsing plugin enabled, so having this in the environment variables allows us to activate the plugin, `carbon_txt.process_document` that contains the CSRD parsing document.

I haven't given the file a more descriptive name yet, as I'm not sure if we want to have a `greenweb` namespace in the project or not yet.

```
ACTIVE_CARBON_TXT_PLUGINS = ("carbon_txt.process_document",)
```

Note - unfortunately, the CSRD parser is very slow on the first parse, especially when we are looking for lots of data points. We'd likely want to cache these, as well as check with the Arelle mailing to see if there aren't some really obvious improvements available to us.

--- 

This pull request introduces several new features and improvements to the `carbon_txt` module. The most significant changes include adding support for processing CSRD reports, enhancing the plugin system, and adding new test cases to ensure the functionality of these features.

### New Features:
* Added a new `process_document` function in `src/carbon_txt/process_document.py` to handle CSRD reports and extract specific datapoints using Arelle.
* Updated the `Credential` class in `src/carbon_txt/schemas.py` to include "csrd-report" as a valid document type.

### Plugin System Enhancements:
* Modified the `CarbonTxtValidator` class in `src/carbon_txt/validators.py` to accept an optional `active_plugins` parameter, allowing for dynamic plugin activation. [[1]](diffhunk://#diff-ee4638d5f5c485cd75d48d52d7f2d32e24512f6ee6d1455711fa44f87d0b7a09L50-R58) [[2]](diffhunk://#diff-ee4638d5f5c485cd75d48d52d7f2d32e24512f6ee6d1455711fa44f87d0b7a09R72-R76)
* Added environment variables for active and default plugins in `src/carbon_txt/web/config/settings/base.py`. [[1]](diffhunk://#diff-ccf5495a22ae8d4d5794a784e145dcebd0b028815a5e8ac2fe80dac75af7412dR39-R40) [[2]](diffhunk://#diff-ccf5495a22ae8d4d5794a784e145dcebd0b028815a5e8ac2fe80dac75af7412dR187)

### Testing Improvements:
* Introduced a new test case in `tests/test_internal_plugins.py` to validate the processing of a CSRD report using the new plugin system.
* Added a new fixture in `tests/conftest.py` for generating a minimal carbon.txt file with a CSRD report link.