### PR TITLE
Add safer raising of exceptions via the API

### DIFF
--- a/src/carbon_txt/exceptions.py
+++ b/src/carbon_txt/exceptions.py
@@ -1,3 +1,6 @@
+import json
+
+
 class InsecureKeyException(Exception):
     """
     Raised when the default SECRET_KEY is used in a
@@ -22,3 +25,35 @@ class NotParseableTOML(Exception):
     """
 
     pass
+
+
+class NoMatchingDatapointsError(ValueError):
+    """
+    Thrown when a report does not have the expected datapoint.
+
+    This could be because a data point is either
+    1. missing, or
+    2. intentionally omitted because it was deemed immaterial
+    """
+
+    def __init__(self, message: str, datapoint_short_code: str) -> None:
+        super().__init__(message)
+        self.datapoint_short_code = datapoint_short_code
+
+    def __dict__(self):
+        return {
+            "message": self.args[0],  # ValueError stores the message in args
+            "datapoint_short_code": self.datapoint_short_code,
+        }
+
+    def __str__(self) -> str:
+        return f"SerializableObject(datapoint_short_code={self.datapoint_short_code})"
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__())
+
+
+class NoLoadableCSRDFile(ValueError):
+    """
+    Thrown when a the link CSRD file can't be loaded by Arelle.
+    """

--- a/src/carbon_txt/process_csrd_document.py
+++ b/src/carbon_txt/process_csrd_document.py
@@ -30,7 +30,7 @@ def process_document(
     and use Arelle to parse them for selected datapoints
     """
     log_safely(
-        f"{__name__}: Processing supporting document: {document.url} for {document.domain}",
+        f"{plugin_name}: Processing supporting document: {document.url} for {document.domain}",
         logs=logs,
     )
 

--- a/src/carbon_txt/processors.py
+++ b/src/carbon_txt/processors.py
@@ -7,26 +7,7 @@ from arelle.RuntimeOptions import RuntimeOptions  # type: ignore
 from pydantic import BaseModel
 
 import typing
-
-
-class NoMatchingDatapointsError(ValueError):
-    """
-    Thrown when a report does not have the expected datapoint.
-
-    This could be because a data point is either
-    1. missing, or
-    2. intentionally omitted because it was deemed immaterial
-    """
-
-    def __init__(self, message: str, datapoint_short_code: str) -> None:
-        super().__init__(message)
-        self.datapoint_short_code = datapoint_short_code
-
-
-class NoLoadableCSRDFile(ValueError):
-    """
-    Thrown when a the link CSRD file can't be loaded by Arelle.
-    """
+from .exceptions import NoMatchingDatapointsError, NoLoadableCSRDFile
 
 
 class DataPoint(BaseModel):

--- a/src/carbon_txt/validators.py
+++ b/src/carbon_txt/validators.py
@@ -89,7 +89,7 @@ class CarbonTxtValidator:
         self, validation_results: schemas.CarbonTxtFile
     ) -> dict[str, list] | dict:
         supporting_documents = validation_results.org.credentials
-        result_list = {}
+        result_list: dict[str, list] = {}
 
         if not supporting_documents:
             return result_list
@@ -140,7 +140,6 @@ class CarbonTxtValidator:
                 result_list = self._append_document_processing(validation_results)
 
             assert len(result_list) == 1
-
             return ValidationResult(
                 result=validation_results,
                 logs=self.event_log,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,11 @@ import pytest
 import pathlib
 
 
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 @pytest.fixture
 def minimal_carbon_txt_org():
     """
@@ -70,3 +75,33 @@ def minimal_carbon_txt_org_with_csrd_file():
             { domain='used-in-tests.carbontxt.org', doctype = 'csrd-report', url = 'https://used-in-tests.carbontxt.org/esrs-e1-efrag-2026-12-31-en.xhtml'}
         ]
     """  # noqa
+
+
+@pytest.fixture()
+def reset_plugin_registry():
+    """
+    Reset the plugin registry to the default state. We need to do this
+    because the plugin framework we have doesn't reset on each test, and
+    if we set up a plugin in one test, it can still be active in the next.
+    """
+    from carbon_txt.plugins import pm
+
+    modules = pm.get_plugins()
+    logger.debug(f"\n current modules: {modules}")
+    for mod in modules:
+        logger.debug(f"\n Unregistering plugin {mod}")
+        pm.unregister(mod)
+
+    logger.debug(f"\n updated: {pm.get_plugins()}")
+
+    return pm
+
+
+@pytest.fixture()
+def settings_with_active_csrd_greenweb_plugin(reset_plugin_registry, settings):
+    settings.ACTIVE_CARBON_TXT_PLUGINS = ["carbon_txt.process_csrd_document"]
+
+
+@pytest.fixture()
+def settings_with_plugin_dir_set(reset_plugin_registry, settings):
+    settings.CARBON_TXT_PLUGINS_DIR = "tests/test_plugins"

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -7,11 +7,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
-def settings_with_plugin_dir_set(settings):
-    settings.CARBON_TXT_PLUGINS_DIR = "tests/test_plugins"
-
-
 @pytest.mark.parametrize("url_suffix", ["", "/"])
 def test_hitting_validate_endpoint_ok(
     live_server, shorter_carbon_txt_string, url_suffix

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -97,8 +97,8 @@ def test_hitting_validate_with_plugins_dir_set(
     # we need the transactional_db fixture because without it the
     # live_server from the previous tests is used, and
     # they do not have a `plugins_dir` active
-    transactional_db,
     settings_with_plugin_dir_set,
+    transactional_db,
     live_server,
     shorter_carbon_txt_string,
 ):

--- a/tests/test_internal_plugins.py
+++ b/tests/test_internal_plugins.py
@@ -1,41 +1,13 @@
-import pytest
+# import pytest
 from carbon_txt import validators  # type: ignore
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
-def reset_plugin_registry():
-    """
-    Reset the plugin registry to the default state. We need to do this
-    because the plugin framework we have doesn't reset on each test, and
-    if we set up a plugin in one test, it can still be active in the next.
-    """
-    from carbon_txt.plugins import pm
-
-    modules = pm.get_plugins()
-    print(f"\n current modules: {modules}")
-    for mod in modules:
-        print(f"\n Unregistering plugin {mod}")
-        pm.unregister(mod)
-
-    print(f"\n updated: {pm.get_plugins()}")
-
-    return pm
-
-
-@pytest.fixture()
-def settings_with_active_csrd_plugin(reset_plugin_registry, settings):
-    settings.ACTIVE_CARBON_TXT_PLUGINS = ["carbon_txt.process_csrd_document"]
-
-    return settings
-
-
 class TestCarbonTxtValidatorWithCSRDPlugin:
     def test_validate_carbon_txt_file_with_csrd_report(
-        self,
-        settings_with_active_csrd_plugin,
+        self, settings_with_active_csrd_greenweb_plugin, settings
     ):
         """
         Test that we can validate a carbon.txt file valid CSRD report, and that
@@ -43,7 +15,7 @@ class TestCarbonTxtValidatorWithCSRDPlugin:
         """
 
         validator = validators.CarbonTxtValidator(
-            active_plugins=settings_with_active_csrd_plugin.ACTIVE_CARBON_TXT_PLUGINS
+            active_plugins=settings.ACTIVE_CARBON_TXT_PLUGINS
         )
 
         test_domain = "used-in-tests.carbontxt.org"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,5 @@
 from carbon_txt import validators  # type: ignore
-
-validator = validators.CarbonTxtValidator()
+import pytest
 
 
 class TestCarbonTxtValidator:
@@ -9,6 +8,7 @@ class TestCarbonTxtValidator:
         This should show a failure, as thegreenwebfoundation.org does not currently have a carbon.txt file,
         but does serve content at the root path (i.e. '/')
         """
+        validator = validators.CarbonTxtValidator()
         res = validator.validate_url("https://www.thegreenwebfoundation.org")
         assert not res.result
         assert res.exceptions
@@ -17,6 +17,7 @@ class TestCarbonTxtValidator:
         """
         This should show a failure, as thegreenwebfoundation.org does not currently have a carbon.txt file
         """
+        validator = validators.CarbonTxtValidator()
         res = validator.validate_url("https://www.thegreenwebfoundation.org/carbon.txt")
         assert not res.result
         assert res.exceptions
@@ -25,6 +26,7 @@ class TestCarbonTxtValidator:
         """
         This should show a failure safely, as the URL is not reachable
         """
+        validator = validators.CarbonTxtValidator()
         res = validator.validate_url("https://does-not-matter.carbontxt.org/carbon.txt")
 
         assert not res.result
@@ -34,9 +36,30 @@ class TestCarbonTxtValidator:
         """
         This should safely handle multiple validation errors gracefully
         """
+        validator = validators.CarbonTxtValidator()
         res = validator.validate_url(
-            "https://99ddb36a.used-in-tests-carbontxt.pages.dev/multiple-exceptions.carbon.txt"
+            "https://used-in-tests-carbontxt.pages.dev/multiple-exceptions.carbon.txt"
         )
 
         assert not res.result
         assert res.exceptions
+
+    @pytest.mark.skip(
+        "This test is failing, as we now return meaningful exceptions from the csrd plugin. We need dummy plugin that returns empty results for csrd files"
+    )
+    def test_validate_file_with_correct_syntax_but_no_results_from_plugins(
+        self, reset_plugin_registry, settings
+    ):
+        """
+        When we try to validate a file that has correct syntax, but has no usable results coming
+        back from the plugins, we should still get a successful result to show that the syntax
+        is correct.
+        """
+        validator = validators.CarbonTxtValidator()
+        res = validator.validate_url(
+            "https://used-in-tests.carbontxt.org/carbon-txt-with-csrd-no-renewables-data.txt"
+        )
+
+        assert res.result
+        assert not res.document_results
+        assert not res.exceptions


### PR DESCRIPTION
The PR improves the handling of exceptions raised when parsing links documents in a carbon.txt file. It's intended to handle the case of parsing CSRD reports, but should also work for any plugin that raises the same `NoMatchingDatapointsError` exception when parsing a document, and passes them along in its output.

---

This pull request includes several changes aimed at improving error handling, logging, and plugin management within the `carbon_txt` module. The most significant changes involve the addition of new exception classes, enhancements to logging, and updates to the plugin system to ensure better test isolation and error reporting.

### Exception Handling Enhancements:
* Added `NoMatchingDatapointsError` and `NoLoadableCSRDFile` exception classes to `src/carbon_txt/exceptions.py` for more specific error reporting.
* Updated `src/carbon_txt/processors.py` to import these new exception classes from `src/carbon_txt/exceptions.py`.

### Logging Improvements:
* Enhanced logging in `src/carbon_txt/finders.py` to provide more detailed information when DNS lookups fail or unexpected errors occur. [[1]](diffhunk://#diff-b4b173d63a512a58ae26461037b3a9f992f923eb31834e9de9db407e098f4e74R90-R92) [[2]](diffhunk://#diff-b4b173d63a512a58ae26461037b3a9f992f923eb31834e9de9db407e098f4e74R222-R226)
* Added debug logging in `src/carbon_txt/validators.py` to track plugin directory and active plugins during initialization. [[1]](diffhunk://#diff-ee4638d5f5c485cd75d48d52d7f2d32e24512f6ee6d1455711fa44f87d0b7a09R63-R65) [[2]](diffhunk://#diff-ee4638d5f5c485cd75d48d52d7f2d32e24512f6ee6d1455711fa44f87d0b7a09L83-R120)

### Plugin Management:
* Introduced `reset_plugin_registry` and other fixtures in `tests/conftest.py` to ensure plugins are reset between tests, preventing cross-test contamination.
* Modified `tests/test_api_external.py` and `tests/test_internal_plugins.py` to use these new fixtures, enhancing test reliability. [[1]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1L105-R101) [[2]](diffhunk://#diff-e768b6933006b04d173d70230461be422afaa022f5fe9f6dda73a3f5f116c85fL1-R18)

### API and Validation Updates:
* Added a `sanitize_document_results` function in `src/carbon_txt/web/api.py` to convert exceptions to dictionaries for better JSON serialization.
* Updated the `validate_contents` and `validate_url` functions in `src/carbon_txt/web/api.py` to instantiate the validator within the function scope, ensuring the latest settings are used. [[1]](diffhunk://#diff-a7d46725d3e2c1b29c33a4ec373597f2fa5ca5faf2ba88f30fb82d47d4b2acbcR86-R103) [[2]](diffhunk://#diff-a7d46725d3e2c1b29c33a4ec373597f2fa5ca5faf2ba88f30fb82d47d4b2acbcR130-R145)

### Test Enhancements:
* Improved test isolation and reliability by ensuring each test has a clean plugin state and appropriate settings. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R78-R107) [[2]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1R121-R156)
* Added a new test in `tests/test_api_external.py` to verify error handling when plugins raise exceptions.

These changes collectively enhance the robustness, maintainability, and testability of the `carbon_txt` module.