### PR TITLE
Add structlog for more manageable logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "django-cors-headers>=4.6.0",
     "django-environ>=0.11.2",
     "django-ninja>=1.3.0",
+    "django-structlog>=9.0.0",
     "django-stubs[compatible-mypy]>=5.1.1",
     "dnspython>=2.7.0",
     "granian>=1.6.2",

--- a/src/carbon_txt/cli.py
+++ b/src/carbon_txt/cli.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import subprocess
 import sys
@@ -14,7 +13,9 @@ from django.core.management import execute_from_command_line
 
 from . import exceptions, schemas, validators
 
-logger = logging.getLogger(__name__)
+import structlog
+
+logger = structlog.get_logger()
 
 app = typer.Typer(no_args_is_help=True)
 validate_app = typer.Typer()

--- a/src/carbon_txt/finders.py
+++ b/src/carbon_txt/finders.py
@@ -1,4 +1,3 @@
-import logging
 import pathlib
 from pathlib import Path
 from typing import Optional
@@ -11,9 +10,11 @@ from .exceptions import UnreachableCarbonTxtFile
 
 from . import parsers_toml
 
-logger = logging.getLogger(__name__)
+from structlog import get_logger
 
-logger.setLevel(logging.DEBUG)
+import logging
+
+logger = get_logger()
 
 
 parser = parsers_toml.CarbonTxtParser()
@@ -89,6 +90,9 @@ class FileFinder:
             return None
         except dns.resolver.NXDOMAIN as ex:
             logger.info(f"No result from TXT lookup: {ex.msg}")
+            return None
+        except Exception as ex:
+            logger.exception(f"New exception: {ex}")
             return None
 
         return None
@@ -219,8 +223,9 @@ class FileFinder:
             raise UnreachableCarbonTxtFile(
                 f"Could not connect to {parsed_uri.geturl()}."
             )
+
         except Exception as ex:
-            logger.error(f"Unexpected error fetching {parsed_uri.geturl()}: {ex}")
+            logger.exception(f"Unexpected error fetching {parsed_uri.geturl()}: {ex}")
             raise UnreachableCarbonTxtFile(
                 f"Could not connect to {parsed_uri.geturl()}."
             )

--- a/src/carbon_txt/parsers_toml.py
+++ b/src/carbon_txt/parsers_toml.py
@@ -6,10 +6,11 @@ import pydantic
 import typing
 
 import logging
+from structlog import get_logger
 
-logger = logging.getLogger(__name__)
-# Do not surface warning messages, as we show them at the end anyway.
-logger.setLevel(logging.ERROR)
+logger = get_logger()
+
+# # Do not surface warning messages, as we show them at the end anyway.
 
 
 def log_safely(log_message: str, logs: typing.Optional[list], level=logging.INFO):

--- a/src/carbon_txt/process_csrd_document.py
+++ b/src/carbon_txt/process_csrd_document.py
@@ -4,7 +4,10 @@ from .processors import CSRDProcessor
 import logging
 from typing import Optional
 
-logger = logging.getLogger(__name__)
+
+from structlog import get_logger
+
+logger = get_logger()
 
 
 def log_safely(log_message: str, logs: Optional[list], level=logging.INFO):

--- a/src/carbon_txt/processors.py
+++ b/src/carbon_txt/processors.py
@@ -9,6 +9,10 @@ from pydantic import BaseModel
 import typing
 from .exceptions import NoMatchingDatapointsError, NoLoadableCSRDFile
 
+import structlog
+
+logger = structlog.getLogger(__name__)
+
 
 class DataPoint(BaseModel):
     """
@@ -62,11 +66,28 @@ class CSRDProcessor:
 
         options = RuntimeOptions(
             entrypointFile=str(report_url),
+            # TODO it's not clear how to get the output from the logger to only log to
+            # the handler. We ideally want to ONLY log to the handler, but there always seems to be
+            # output logged to stdout, even if we pass in a null handler.
+            # the only option we seem to have is to set the log level
+            logLevel="ERROR",
+            logFile="logToBuffer",
             # we need to keep the file open to fetch data from the xml
             # file later, when we call various method on the object
             # TODO: does file close when this object is garbage collected?
             keepOpen=True,
         )
+
+        # TODO: clean this up once we figure out how to ONLY log to the handler
+        # import logging
+
+        # nuller = logging.NullHandler()
+        # handler = logging.StreamHandler()
+
+        # "plain_console": {
+        #     "()": structlog.stdlib.ProcessorFormatter,
+        #     "processor": structlog.dev.ConsoleRenderer(),
+        # },
 
         with Session() as session:
             session.run(options)

--- a/src/carbon_txt/validators.py
+++ b/src/carbon_txt/validators.py
@@ -1,21 +1,22 @@
-import logging
-from dataclasses import dataclass
 import importlib
-
-
+import logging
 import pathlib
-import httpx
+from dataclasses import dataclass
 from typing import Optional, Union
 
-from . import exceptions, finders, parsers_toml, schemas  # noqa
-from .plugins import pm, module_from_path
+import httpx
 import pydantic
 import pydantic_core
+import structlog
+
+from . import exceptions, finders, parsers_toml, schemas  # noqa
+from .plugins import module_from_path, pm
 
 file_finder = finders.FileFinder()
 parser = parsers_toml.CarbonTxtParser()
 
-logger = logging.getLogger(__name__)
+
+logger = structlog.get_logger()
 
 
 @dataclass
@@ -61,8 +62,12 @@ class CarbonTxtValidator:
         provided plugin directory `plugins_dir`, and activating any plugins
         """
 
-        logger.debug("plugins_dir", plugins_dir)
-        logger.debug("active_plugins", active_plugins)
+        logger.info(
+            f"plugins_dir: {plugins_dir}",
+        )
+        logger.info(
+            f"active_plugins {active_plugins}",
+        )
         if plugins_dir is not None:
             self.plugins_dir = plugins_dir
             plugins_path = pathlib.Path(plugins_dir).resolve()

--- a/src/carbon_txt/web/api.py
+++ b/src/carbon_txt/web/api.py
@@ -1,14 +1,15 @@
-from ninja import NinjaAPI, Schema
-from django.http import HttpRequest, HttpResponse  # noqa
-from django.conf import settings
-
 import pydantic
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse  # noqa
+from ninja import NinjaAPI, Schema
+from structlog import get_logger
 
-from .. import finders, validators, schemas, exceptions  # noqa
-import logging
+from .. import exceptions, finders, schemas, validators  # noqa
 
 file_finder = finders.FileFinder()
-logger = logging.getLogger(__name__)
+
+
+logger = get_logger()
 
 # Initialize the NinjaAPI with OpenAPI documentation details
 ninja_api = NinjaAPI(
@@ -96,6 +97,8 @@ def validate_contents(
             doc_results = sanitize_document_results(
                 validation_results.document_results or {}
             )
+        # TODO: make sure empty doc_results show as {}, with no keys
+        # https://github.com/thegreenwebfoundation/carbon-txt-validator/issues/59
         return {
             "success": True,
             "data": carbon_txt_file,
@@ -138,7 +141,8 @@ def validate_url(
             doc_results = sanitize_document_results(
                 validation_results.document_results or {}
             )
-
+        # TODO: make sure empty doc_results show as {}, with no keys
+        # https://github.com/thegreenwebfoundation/carbon-txt-validator/issues/59
         return {
             "success": True,
             "data": carbon_txt_file,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,9 @@ import pytest
 import pathlib
 
 
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 @pytest.fixture

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 import httpx
 import pytest
-import logging
 
-logger = logging.getLogger(__name__)
+
+from structlog import get_logger
+
+logger = get_logger()
 
 
 @pytest.mark.parametrize("url_suffix", ["", "/"])

--- a/tests/test_internal_plugins.py
+++ b/tests/test_internal_plugins.py
@@ -1,8 +1,10 @@
 # import pytest
 from carbon_txt import validators  # type: ignore
-import logging
 
-logger = logging.getLogger(__name__)
+
+from structlog import get_logger
+
+logger = get_logger()
 
 
 class TestCarbonTxtValidatorWithCSRDPlugin:

--- a/tests/test_plugins/process_document.py
+++ b/tests/test_plugins/process_document.py
@@ -3,7 +3,10 @@ from carbon_txt.hookspecs import hookimpl  # type: ignore
 import logging
 from typing import Optional
 
-logger = logging.getLogger(__name__)
+from structlog import get_logger
+
+logger = get_logger()
+
 
 plugin_name = "test_plugin"
 

--- a/tests/test_processor_csrd.py
+++ b/tests/test_processor_csrd.py
@@ -1,17 +1,16 @@
 import pytest
-import logging
 import pathlib
 from carbon_txt import processors  # type: ignore
 
-from rich.logging import RichHandler
 
 from arelle import (  # type: ignore
     ModelXbrl,
 )
 
-logger = logging.getLogger(__name__)
-logger.addHandler(RichHandler())
-# logger.setLevel(logging.INFO)
+
+from structlog import get_logger
+
+logger = get_logger()
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -117,6 +117,7 @@ dependencies = [
     { name = "django-cors-headers" },
     { name = "django-environ" },
     { name = "django-ninja" },
+    { name = "django-structlog" },
     { name = "django-stubs", extra = ["compatible-mypy"] },
     { name = "dnspython" },
     { name = "granian" },
@@ -149,6 +150,7 @@ requires-dist = [
     { name = "django-cors-headers", specifier = ">=4.6.0" },
     { name = "django-environ", specifier = ">=0.11.2" },
     { name = "django-ninja", specifier = ">=1.3.0" },
+    { name = "django-structlog", specifier = ">=9.0.0" },
     { name = "django-stubs", extras = ["compatible-mypy"], specifier = ">=5.1.1" },
     { name = "dnspython", specifier = ">=2.7.0" },
     { name = "granian", specifier = ">=1.6.2" },
@@ -414,6 +416,18 @@ wheels = [
 ]
 
 [[package]]
+name = "django-ipware"
+version = "7.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-ipware" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/64/c7e4791edf01ba483cce444770b3e6a930ba12195ba1eeb37b5bf6dce8a8/django-ipware-7.0.1.tar.gz", hash = "sha256:d9ec43d2bf7cdf216fed8d494a084deb5761a54860a53b2e74346a4f384cff47", size = 6827 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/33/bf539925b102d68200da5b1d3eacb8aa5d5d9a065972e8b8724d0d53bb0d/django_ipware-7.0.1-py2.py3-none-any.whl", hash = "sha256:db16bbee920f661ae7f678e4270460c85850f03c6761a4eaeb489bdc91f64709", size = 6425 },
+]
+
+[[package]]
 name = "django-ninja"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -424,6 +438,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9c/77/89ee4ebaa5151b7d85cebaf8d6ec0b9e5074326c3ad8259c763763306d51/django_ninja-1.3.0.tar.gz", hash = "sha256:5b320e2dc0f41a6032bfa7e1ebc33559ae1e911a426f0c6be6674a50b20819be", size = 3702324 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/72/fd2589323b40893d3224e174eeec0c4ce5a42c7d2d384d11ba269ad4d050/django_ninja-1.3.0-py3-none-any.whl", hash = "sha256:f58096b6c767d1403dfd6c49743f82d780d7b9688d9302ecab316ac1fa6131bb", size = 2423381 },
+]
+
+[[package]]
+name = "django-structlog"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+    { name = "django-ipware" },
+    { name = "structlog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/43/3d849f0e4bed479f283923ff07cb64dc1e0c0af7a3ed0ba3052725a4d48b/django_structlog-9.0.0.tar.gz", hash = "sha256:0ada1ac0fa4e90a499fc9ce22fc164830304e7219cab12d3b5ef9c2f2967ff5b", size = 22349 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/6c/991eedcab585203a008eafdbb0c63510595a4fb5ba8bb91098fa1b7184e5/django_structlog-9.0.0-py3-none-any.whl", hash = "sha256:8c32097b3f09b2727b746d6cdf4f50565c62fd040b3a0c98cb731de0b380b854", size = 17535 },
 ]
 
 [[package]]
@@ -1452,6 +1481,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-ipware"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/60/da4426c3e9aee56f08b24091a9e85a0414260f928f97afd0013dfbd0332f/python_ipware-3.0.0.tar.gz", hash = "sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062", size = 16609 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/bd/ccd7416fdb30f104ddf6cfd8ee9f699441c7d9880a26f9b3089438adee05/python_ipware-3.0.0-py3-none-any.whl", hash = "sha256:fc936e6e7ec9fcc107f9315df40658f468ac72f739482a707181742882e36b60", size = 10761 },
+]
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1855,6 +1893,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3e/da/1fb4bdb72ae12b834becd7e1e7e47001d32f91ec0ce8d7bc1b618d9f0bd9/starlette-0.41.2.tar.gz", hash = "sha256:9834fd799d1a87fd346deb76158668cfa0b0d56f85caefe8268e2d97c3468b62", size = 2573867 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl", hash = "sha256:fbc189474b4731cf30fcef52f18a8d070e3f3b46c6a04c97579e85e6ffca942d", size = 73259 },
+]
+
+[[package]]
+name = "structlog"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/fe/578db23e17392a8693b45a7b7dc6985370f51dd937157def8ecc7b20930d/structlog-25.1.0.tar.gz", hash = "sha256:2ef2a572e0e27f09664965d31a576afe64e46ac6084ef5cec3c2b8cd6e4e3ad3", size = 1364973 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/14/e9aed6c820fa166e8a19a19e663e98bd5538004d68a70c5752458ca3656e/structlog-25.1.0-py3-none-any.whl", hash = "sha256:843fe4f254540329f380812cbe612e1af5ec5b8172205ae634679cd35a6d6321", size = 68921 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request includes several changes to the logging system across the codebase, transitioning from the standard `logging` library to `structlog`. Additionally, it introduces a new dependency and updates some exception handling.

### Logging System Transition:
* Replaced `logging` with `structlog` across multiple files, including `src/carbon_txt/cli.py`, `src/carbon_txt/finders.py`, `src/carbon_txt/parsers_toml.py`, `src/carbon_txt/process_csrd_document.py`, `src/carbon_txt/processors.py`, `src/carbon_txt/validators.py`, `src/carbon_txt/web/api.py`, and various test files. [[1]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaL17-R18) [[2]](diffhunk://#diff-b4b173d63a512a58ae26461037b3a9f992f923eb31834e9de9db407e098f4e74L14-R17) [[3]](diffhunk://#diff-047bbadaeedbdc3b3061daa6ee4c06974ecd2d6c84a58d27cc9ba8db87ebb9c1R9-R13) [[4]](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52L7-R10) [[5]](diffhunk://#diff-52d4333509fb9634b01e7493d3fb0dddbdb587725f382cca68cab31a064854c1R12-R15) [[6]](diffhunk://#diff-ee4638d5f5c485cd75d48d52d7f2d32e24512f6ee6d1455711fa44f87d0b7a09L1-R19) [[7]](diffhunk://#diff-a7d46725d3e2c1b29c33a4ec373597f2fa5ca5faf2ba88f30fb82d47d4b2acbcL1-R12) [[8]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L5-R7) [[9]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1L5-R9) [[10]](diffhunk://#diff-e768b6933006b04d173d70230461be422afaa022f5fe9f6dda73a3f5f116c85fL3-R7) [[11]](diffhunk://#diff-963b732f23b4ebf1df43850348303a689fa8e6b8b966f9e34d54513d0c7b91eaL6-R9) [[12]](diffhunk://#diff-d5b371c3981bfbca90ec6d6fd4748c742c5d8585dcb42a8937461ae388375833L2-R13)

### Dependency Update:
* Added `django-structlog>=9.0.0` to the `pyproject.toml` dependencies.

### Exception Handling Improvements:
* Enhanced exception handling in `src/carbon_txt/finders.py` by adding a new generic exception catch and logging it using `logger.exception`. [[1]](diffhunk://#diff-b4b173d63a512a58ae26461037b3a9f992f923eb31834e9de9db407e098f4e74R94-R96) [[2]](diffhunk://#diff-b4b173d63a512a58ae26461037b3a9f992f923eb31834e9de9db407e098f4e74R226-R228)

### Configuration Changes:
* Updated `src/carbon_txt/web/config/settings/base.py` to configure `structlog` and added `django_structlog` to installed apps and middleware. [[1]](diffhunk://#diff-ccf5495a22ae8d4d5794a784e145dcebd0b028815a5e8ac2fe80dac75af7412dL13-R94) [[2]](diffhunk://#diff-ccf5495a22ae8d4d5794a784e145dcebd0b028815a5e8ac2fe80dac75af7412dR157) [[3]](diffhunk://#diff-ccf5495a22ae8d4d5794a784e145dcebd0b028815a5e8ac2fe80dac75af7412dR170)

### Code Cleanup:
* Removed unused `logging` imports from various files. [[1]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaL2) [[2]](diffhunk://#diff-b4b173d63a512a58ae26461037b3a9f992f923eb31834e9de9db407e098f4e74L1) [[3]](diffhunk://#diff-ee4638d5f5c485cd75d48d52d7f2d32e24512f6ee6d1455711fa44f87d0b7a09L1-R19) [[4]](diffhunk://#diff-a7d46725d3e2c1b29c33a4ec373597f2fa5ca5faf2ba88f30fb82d47d4b2acbcL1-R12) [[5]](diffhunk://#diff-d5b371c3981bfbca90ec6d6fd4748c742c5d8585dcb42a8937461ae388375833L2-R13)For clearer and more manageable logging