### PR TITLE
Add new defaults for seeing logger output

### DIFF
--- a/src/carbon_txt/web/config/settings/base.py
+++ b/src/carbon_txt/web/config/settings/base.py
@@ -44,32 +44,29 @@ LOGGING = {
         "console": {
             "class": "logging.StreamHandler",
             "formatter": "plain_console",
-            # "formatter": "json_formatter",
         },
         "nullhandler": {
             "class": "logging.NullHandler",
         },
     },
     "loggers": {
-        "django_structlog": {
-            "handlers": ["console"],
-            "level": "INFO",
-        },
+        # set our default logger
         "root": {
             "handlers": ["console"],
             "level": "INFO",
             "propagate": True,
         },
+        "django_structlog": {
+            "level": "INFO",
+        },
         "httpx": {
-            "handlers": ["console"],
             "level": "WARNING",
         },
         "httpcore": {
-            "handlers": ["console"],
             "level": "INFO",
         },
-        "carbon_txt.processors": {
-            "level": "DEBUG",
+        "carbon_txt": {
+            "level": "INFO",
         },
     },
 }

--- a/src/carbon_txt/web/config/settings/production.py
+++ b/src/carbon_txt/web/config/settings/production.py
@@ -5,3 +5,10 @@ ALLOWED_HOSTS = ["127.0.0.1", "localhost", ".localhost", ".greenweb.org"]
 
 WSGI_APPLICATION = "carbon_txt.web.config.wsgi.application"
 ROOT_URLCONF = "carbon_txt.web.config.urls"
+
+
+# switch to using a logger better suited for production
+LOGGING["handlers"]["console"] = {  # type: ignore # noqa
+    "class": "logging.StreamHandler",
+    "formatter": "key_value",
+}

--- a/src/carbon_txt/web/config/settings/test.py
+++ b/src/carbon_txt/web/config/settings/test.py
@@ -5,3 +5,35 @@ ALLOWED_HOSTS.extend(["127.0.0.1", "localhost"])  # noqa
 
 WSGI_APPLICATION = "carbon_txt.web.config.wsgi.application"
 ROOT_URLCONF = "carbon_txt.web.config.urls"
+
+LOGGING["handlers"]["console"] = {  # type: ignore # noqa
+    "class": "logging.StreamHandler",
+    # "formatter": "key_value",
+    "formatter": "plain_console",
+    # "formatter": "json_formatter",
+}
+
+LOGGING["loggers"] = {  # type: ignore # noqa
+    "root": {
+        "handlers": ["console"],
+        # make test logs much more quiet. Set this to INFO and specific loggers
+        # below to DEBUG for troubleshooting
+        "level": "ERROR",
+        # "propagate": True,
+    },
+    #     "django_structlog": {
+    #         # "level": "ERROR",
+    #     },
+    #     "httpx": {
+    #         # "level": "WARNING",
+    #     },
+    #     "httpcore": {
+    #         # "level": "INFO",
+    #     },
+    #     "carbon_txt": {
+    #         # "level": "INFO",
+    #     },
+    #     "test_plugin": {
+    #         # "level": "ERROR",
+    #     },
+}

--- a/tests/test_plugins/process_document.py
+++ b/tests/test_plugins/process_document.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from structlog import get_logger
 
-logger = get_logger()
+logger = get_logger("test_plugin")
 
 
 plugin_name = "test_plugin"


### PR DESCRIPTION
This pull request includes several changes to the logging configuration across different environments and a minor change to a test plugin. The main goal is to improve logging consistency and make the logs more suitable for each environment.

### Logging Configuration Changes:

* [`src/carbon_txt/web/config/settings/base.py`](diffhunk://#diff-ccf5495a22ae8d4d5794a784e145dcebd0b028815a5e8ac2fe80dac75af7412dL47-R69): Updated the default logger configuration to set the "root" logger and adjusted the log levels for various loggers.
* [`src/carbon_txt/web/config/settings/production.py`](diffhunk://#diff-507dc1e5325b04d2c850d1d5d4c7ba8901bea0bf4f428f64ad39878e13bb0203R8-R14): Switched the console handler to use a "key_value" formatter, which is better suited for production.
* [`src/carbon_txt/web/config/settings/test.py`](diffhunk://#diff-5e331e72dbe70e63da146ebab22be38d99d749d85d415e47853c72c9037b2fc8R8-R39): Modified the console handler to use the "plain_console" formatter and adjusted the log levels to make test logs quieter by default.

### Test Plugin Changes:

* [`tests/test_plugins/process_document.py`](diffhunk://#diff-963b732f23b4ebf1df43850348303a689fa8e6b8b966f9e34d54513d0c7b91eaL8-R8): Changed the logger name to "test_plugin" for better identification in logs.