### PR TITLE
Make sure we have readable versions of exceptions in our API

### DIFF
--- a/src/carbon_txt/exceptions.py
+++ b/src/carbon_txt/exceptions.py
@@ -1,6 +1,3 @@
-import json
-
-
 class InsecureKeyException(Exception):
     """
     Raised when the default SECRET_KEY is used in a
@@ -36,21 +33,22 @@ class NoMatchingDatapointsError(ValueError):
     2. intentionally omitted because it was deemed immaterial
     """
 
-    def __init__(self, message: str, datapoint_short_code: str) -> None:
+    def __init__(
+        self,
+        message: str,
+        datapoint_short_code: str,
+        datapoint_readable_label: str,
+    ) -> None:
         super().__init__(message)
         self.datapoint_short_code = datapoint_short_code
+        self.datapoint_readable_label = datapoint_readable_label
 
     def __dict__(self):
         return {
             "message": self.args[0],  # ValueError stores the message in args
             "datapoint_short_code": self.datapoint_short_code,
+            "datapoint_readable_label": self.datapoint_readable_label,
         }
-
-    def __str__(self) -> str:
-        return f"SerializableObject(datapoint_short_code={self.datapoint_short_code})"
-
-    def to_json(self) -> str:
-        return json.dumps(self.__dict__())
 
 
 class NoLoadableCSRDFile(ValueError):

--- a/src/carbon_txt/processors.py
+++ b/src/carbon_txt/processors.py
@@ -119,11 +119,14 @@ class CSRDProcessor:
         datapoints = []
         try:
             res = self.xbrls[0].factsByLocalName.get(datapoint_code)
-
+            datapoint_readable_label = self.esrs_datapoints.get(
+                f"esrs:{datapoint_code}"
+            )
             if not res:
                 raise NoMatchingDatapointsError(
                     f"Could not find datapoint with code {datapoint_code}, for report {self.report_url}",
                     datapoint_short_code=datapoint_code,
+                    datapoint_readable_label=datapoint_readable_label,
                 )
 
             for item in res:
@@ -159,6 +162,7 @@ class CSRDProcessor:
             raise NoMatchingDatapointsError(
                 f"Could not find datapoint with code {datapoint_code}",
                 datapoint_short_code=datapoint_code,
+                datapoint_readable_label=datapoint_readable_label,
             )
 
         return datapoints

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -155,4 +155,14 @@ def test_hitting_validate_with_plugins_raising_errors(
     # we should see an error key in every item in the plugin data
     for item in plugin_data:
         assert "error" in item.keys()
+        assert "datapoint_short_code" in item.keys()
+        assert "datapoint_readable_label" in item.keys()
         assert item["error"] == "NoMatchingDatapointsError"
+
+    # check that we see the correct datapoint short code and human friendly value
+    # in at least one of the error messages
+    assert any(
+        item.get("datapoint_short_code")
+        == "PercentageOfRenewableSourcesInTotalEnergyConsumption"
+        for item in plugin_data
+    )


### PR DESCRIPTION
After a chat with Fershad, we decided to add nicer readable label for the datapoints as well in errors.


---

This pull request includes several changes to improve error handling and data processing in the `carbon_txt` module. The most important changes include updating exception handling to include more detailed information, enhancing data retrieval methods, and improving test coverage.

### Exception Handling Improvements:
* [`src/carbon_txt/exceptions.py`](diffhunk://#diff-31fca68fd6e7efba810d6cf2f090d68ea68109f7a2f60bfb98de905ac3842be2L39-L54): Modified the `NoMatchingDatapointsError` class to include a new attribute `datapoint_readable_label` for better error context. Updated the `__init__` method and the `__dict__` method to handle this new attribute.

### Data Retrieval Enhancements:
* [`src/carbon_txt/processors.py`](diffhunk://#diff-52d4333509fb9634b01e7493d3fb0dddbdb587725f382cca68cab31a064854c1L122-R129): Updated the `_get_datapoints_for_datapoint_code` method to retrieve and pass the `datapoint_readable_label` when raising a `NoMatchingDatapointsError`. [[1]](diffhunk://#diff-52d4333509fb9634b01e7493d3fb0dddbdb587725f382cca68cab31a064854c1L122-R129) [[2]](diffhunk://#diff-52d4333509fb9634b01e7493d3fb0dddbdb587725f382cca68cab31a064854c1R165)

### Test Coverage Improvements:
* [`tests/test_api_external.py`](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1R158-R168): Enhanced the `test_hitting_validate_with_plugins_raising_errors` test to check for the presence of `datapoint_short_code` and `datapoint_readable_label` in error messages, ensuring that the new attributes are correctly included in the error handling.