### PR TITLE
Ca issue 59 check empty dict for fish

### DIFF
--- a/src/carbon_txt/validators.py
+++ b/src/carbon_txt/validators.py
@@ -149,7 +149,6 @@ class CarbonTxtValidator:
             if validation_results:
                 result_list = self._append_document_processing(validation_results)
 
-            assert len(result_list) == 1
             return ValidationResult(
                 result=validation_results,
                 logs=self.event_log,

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -166,3 +166,21 @@ def test_hitting_validate_with_plugins_raising_errors(
         == "PercentageOfRenewableSourcesInTotalEnergyConsumption"
         for item in plugin_data
     )
+
+
+def test_hitting_validate_with_zero_plugins_set(
+    transactional_db,
+    live_server,
+    shorter_carbon_txt_string,
+):
+    """
+    Even when no plugins are set, we should still send an empty
+    dictionary / object over the API.
+    """
+    api_url = f"{live_server.url}/api/validate/file"
+    data = {"text_contents": shorter_carbon_txt_string}
+    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
+    assert res.status_code == 200
+    parsed_response = res.json()
+    assert "document_data" in parsed_response.keys()
+    assert parsed_response["document_data"] == {}


### PR DESCRIPTION
This pull request includes changes to the validation logic in `src/carbon_txt/validators.py` and adds a new test case in `tests/test_api_external.py`. The most important changes are:

Validation logic update:

* Removed an unnecessary assertion in the `validate_contents` method to streamline the validation process. (`src/carbon_txt/validators.py`)

Testing improvements:

* Added a new test case `test_hitting_validate_with_zero_plugins_set` to ensure that the API correctly handles scenarios where no plugins are set, returning an empty dictionary/object. (`tests/test_api_external.py`)