### PR TITLE
Update our naming inline for 0.2 of the carbon.txt spec

### DIFF
--- a/docs/adrs/01_adding_plugins_with_pluggy.md
+++ b/docs/adrs/01_adding_plugins_with_pluggy.md
@@ -130,7 +130,7 @@ from carbon_txt import hookimpl
 @hookimpl
 def process_document(document):
     # assume do_some_work is a function defined elsewhere
-    if document.doctype == "csrd-report":
+    if document.doc_type == "csrd-report":
         results = do_some_work(document)
         return results
 

--- a/docs/extending_with_plugins.md
+++ b/docs/extending_with_plugins.md
@@ -99,7 +99,8 @@ Parsed TOML was recognised as valid Carbon.txt file.
 
 -------
 
-CarbonTxtFile(upstream=Upstream(providers=[]), org=Organisation(credentials=[Credential(domain='used-in-tests.carbontxt.org', doctype='sustainability-page', url='https://used-in-tests.carbontxt.org/our-climate-record')]))
+
+CarbonTxtFile(upstream=Upstream(providers=[]), org=Organisation(disclosures=[Disclosure(domain='used-in-tests.carbontxt.org', doc_type='sustainability-page', url='https://used-in-tests.carbontxt.org/our-climate-record')]))
 -------
 
 Results of processing linked documents in the carbon.txt file:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -71,13 +71,13 @@ Should return output, that (once formatted) similar to the JSON below:
   "success": true,
   "data": {
     "upstream": {
-      "providers": []
+      "services": []
     },
     "org": {
-      "credentials": [
+      "disclosures": [
         {
           "domain": "used-in-tests.carbontxt.org",
-          "doctype": "csrd-report",
+          "doc_type": "csrd-report",
           "url": "https://used-in-tests.carbontxt.org/esrs-e1-efrag-2026-12-31-en.xhtml"
         }
       ]
@@ -128,13 +128,13 @@ Our request now returns extra output in the `document_data` part of the object. 
   "success": true,
   "data": {
     "upstream": {
-      "providers": []
+      "services": []
     },
     "org": {
-      "credentials": [
+      "disclosures": [
         {
           "domain": "used-in-tests.carbontxt.org",
-          "doctype": "csrd-report",
+          "doc_type": "csrd-report",
           "url": "https://used-in-tests.carbontxt.org/esrs-e1-efrag-2026-12-31-en.xhtml"
         }
       ]
@@ -175,7 +175,7 @@ Our request now returns extra output in the `document_data` part of the object. 
     "Carbon.txt file parsed as valid TOML.",
     "Parsed TOML was recognised as valid Carbon.txt file.\n",
     "csrd_greenweb: Processing supporting document: https://used-in-tests.carbontxt.org/esrs-e1-efrag-2026-12-31-en.xhtml for used-in-tests.carbontxt.org",
-    "carbon_txt.process_csrd_document: CSRD Report found. Processing report with Arelle: domain='used-in-tests.carbontxt.org' doctype='csrd-report' url='https://used-in-tests.carbontxt.org/esrs-e1-efrag-2026-12-31-en.xhtml'"
+    "carbon_txt.process_csrd_document: CSRD Report found. Processing report with Arelle: domain='used-in-tests.carbontxt.org' doc_type='csrd-report' url='https://used-in-tests.carbontxt.org/esrs-e1-efrag-2026-12-31-en.xhtml'"
   ]
 }
 ```

--- a/src/carbon_txt/process_csrd_document.py
+++ b/src/carbon_txt/process_csrd_document.py
@@ -1,5 +1,5 @@
 from .hookspecs import hookimpl
-from .schemas import CarbonTxtFile, Credential
+from .schemas import CarbonTxtFile, Disclosure
 from .processors import CSRDProcessor
 import logging
 from typing import Optional
@@ -24,7 +24,7 @@ plugin_name = "csrd_greenweb"
 
 @hookimpl
 def process_document(
-    document: Credential,
+    document: Disclosure,
     parsed_carbon_txt_file: Optional[CarbonTxtFile],
     logs: Optional[list],
 ):
@@ -37,7 +37,7 @@ def process_document(
         logs=logs,
     )
 
-    if document.doctype == "csrd-report":
+    if document.doc_type == "csrd-report":
         log_safely(
             f"{__name__}: CSRD Report found. Processing report with Arelle: {document}",
             logs=logs,
@@ -65,7 +65,7 @@ def process_document(
 
     else:
         log_safely(
-            f"{__name__}: Document type {document.doctype} seen. Doing nothing",
+            f"{__name__}: Document type {document.doc_type} seen. Doing nothing",
             logs=logs,
         )
 

--- a/src/carbon_txt/schemas.py
+++ b/src/carbon_txt/schemas.py
@@ -11,7 +11,7 @@ class Service(BaseModel):
     Green Web Platform
     """
 
-    domain: str
+    domain: Optional[str]
     name: Optional[str] = None
     # TODO: python prefers snake_case.
     # javascript prefers camelCase
@@ -45,7 +45,7 @@ class Organisation(BaseModel):
     if it is exclusively relying on services from upstream providers for its green claims.
     """
 
-    credentials: List[Disclosure] = Field(..., min_length=1)
+    disclosures: List[Disclosure] = Field(..., min_length=1)
 
 
 class Upstream(BaseModel):

--- a/src/carbon_txt/schemas.py
+++ b/src/carbon_txt/schemas.py
@@ -3,26 +3,31 @@ from typing import Literal, Optional, List
 from pydantic import BaseModel, Field
 
 
-class Provider(BaseModel):
+class Service(BaseModel):
     """
-    Providers in this context are upstream providers of hosted services.
+    A service in this context is a hosted service, offered by a provider
+    of hosted services.
     The domain is used as key for looking up a corresponding provider in the
     Green Web Platform
     """
 
     domain: str
     name: Optional[str] = None
-    services: Optional[List[str]] = None
+    # TODO: python prefers snake_case.
+    # javascript prefers camelCase
+    # but kebab-case is arguable more common in URLS
+    # how do we support this?
+    service_type: Optional[List[str]] = None
 
 
-class Credential(BaseModel):
+class Disclosure(BaseModel):
     """
-    Credentials are essentially supporting documentation for a claim to be running on
-    green energy.
+    Disclosures are essentially supporting documentation shared by an organisation than can
+    be to be used to substantiate a claim like running on green energy, and so on.
     """
 
     domain: Optional[str] = None
-    doctype: Literal[
+    doc_type: Literal[
         "web-page",
         "annual-report",
         "sustainability-page",
@@ -36,23 +41,23 @@ class Credential(BaseModel):
 class Organisation(BaseModel):
     """
     An Organisation is the entity making the claim to running its infrastructure
-    on green energy. In the very least it should have some credentials point to, even
-    if it is exclusively relying on upstream providers for its green claims.
+    on green energy. In the very least it should have some disclosures point to, even
+    if it is exclusively relying on services from upstream providers for its green claims.
     """
 
-    credentials: List[Credential] = Field(..., min_length=1)
+    credentials: List[Disclosure] = Field(..., min_length=1)
 
 
 class Upstream(BaseModel):
     """
-    Upstream refers to one or more providers of hosted services that the Organisation
+    Upstream refers to one or more hosted services that the Organisation
     is relying on to operate a digital service, like running a website, or application.
     """
 
     # organisations that don't use third party providers could plausibly have an
     # empty upstream list. We also either accept providers as a single string representing
     # a domain, or a dictionary containing the fields defined in the Provider model
-    providers: Optional[List[Provider | str]] = None
+    services: Optional[List[Service | str]] = None
 
 
 class CarbonTxtFile(BaseModel):

--- a/src/carbon_txt/validators.py
+++ b/src/carbon_txt/validators.py
@@ -98,7 +98,7 @@ class CarbonTxtValidator:
     def _append_document_processing(
         self, validation_results: schemas.CarbonTxtFile
     ) -> dict[str, list] | dict:
-        supporting_documents = validation_results.org.credentials
+        supporting_documents = validation_results.org.disclosures
         document_processing_results: dict[str, list] = {}
 
         if not supporting_documents:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,10 +15,10 @@ def minimal_carbon_txt_org():
     """
     return """
         [upstream]
-        providers = []
+        services = []
         [org]
-        credentials = [
-            { domain='used-in-tests.carbontxt.org', doctype = 'sustainability-page', url = 'https://used-in-tests.carbontxt.org/our-climate-record'}
+        disclosures = [
+            { domain='used-in-tests.carbontxt.org', doc_type = 'sustainability-page', url = 'https://used-in-tests.carbontxt.org/our-climate-record'}
         ]
     """  # noqa
 
@@ -32,13 +32,13 @@ def shorter_carbon_txt_string():
 
     short_string = """
         [upstream]
-        providers = [
-        'sys-ten.com',
-        'cdn.com',
+        services = [
+            {domain='sys-ten.com', service_type=['cloud']},
+            {domain='cdn.com', service_type=['cdn']},
         ]
         [org]
-        credentials = [
-            { domain='www.hillbob.de', doctype = 'sustainability-page', url = 'https://www.hillbob.de/klimaneutral'}
+        disclosures = [
+            { domain='www.hillbob.de', doc_type = 'sustainability-page', url = 'https://www.hillbob.de/klimaneutral'}
         ]
     """  # noqa
     return short_string
@@ -69,10 +69,10 @@ def minimal_carbon_txt_org_with_csrd_file():
     """
     return """
         [upstream]
-        providers = []
+        services = []
         [org]
-        credentials = [
-            { domain='used-in-tests.carbontxt.org', doctype = 'csrd-report', url = 'https://used-in-tests.carbontxt.org/esrs-e1-efrag-2026-12-31-en.xhtml'}
+        disclosures = [
+            { domain='used-in-tests.carbontxt.org', doc_type = 'csrd-report', url = 'https://used-in-tests.carbontxt.org/esrs-e1-efrag-2026-12-31-en.xhtml'}
         ]
     """  # noqa
 

--- a/tests/fixtures/aremythirdpartiesgreen.com.carbon-txt.toml
+++ b/tests/fixtures/aremythirdpartiesgreen.com.carbon-txt.toml
@@ -1,5 +1,5 @@
 [upstream]
-providers = [
+services = [
     # These providers include my hosting (Netlify - they use AWS/GCP under the hood),
     # as well as all the third-party services I use on this site.
     # I feel it makes sense to keep these all together.
@@ -13,9 +13,9 @@ providers = [
 ]
 
 [org]
-credentials = [
+disclosures = [
     # These are evidence of things I do to account for the carbon emissions of this website.
-    { domain = "fershad.com", doctype = "webpage", url = "https://fershad.com/for-good/" },
+    { domain = "fershad.com", doc_type = "webpage", url = "https://fershad.com/for-good/" },
 ]
 
 # What would I like to see returned when validating this?

--- a/tests/fixtures/carbon-txt-test.toml
+++ b/tests/fixtures/carbon-txt-test.toml
@@ -1,63 +1,63 @@
 [upstream]
-providers = [
-  { domain = 'sys-ten.com', doctype = 'sustainability-page', url = 'https://www.sys-ten.de/en/about-us/our-data-centers/', aliases = [
+services = [
+  { domain = 'sys-ten.com', doc_type = 'sustainability-page', url = 'https://www.sys-ten.de/en/about-us/our-data-centers/', aliases = [
     "www.sys-ten.com",
     "www.systen.com",
   ] },
-  { domain = 'cdn.com', doctype = 'sustainability-page', url = 'https://cdn.com/company/corporate-responsibility/sustainability' },
+  { domain = 'cdn.com', doc_type = 'sustainability-page', url = 'https://cdn.com/company/corporate-responsibility/sustainability' },
 ]
 
 [org]
 # we don't represent location here right now, and it's important to our model
 # TODO figure out how to represent this
-credentials = [
-  { domain = 'www.hillbob.de', doctype = 'sustainability-page', url = 'https://www.hillbob.de/klimaneutral/', aliases = [
+disclosures = [
+  { domain = 'www.hillbob.de', doc_type = 'sustainability-page', url = 'https://www.hillbob.de/klimaneutral/', aliases = [
     "hillbob.de",
     "hill-bob.de",
   ] },
-  # { domain = 'www.hillbob.de', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  # { domain = 'www.hillbob.de', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'valleytrek.co.uk', doctype = 'sustainability-page', url = 'https://www.alpinetrek.co.uk/climate-neutral/' },
-  # { domain = 'valleytrek.co.uk', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'valleytrek.co.uk', doc_type = 'sustainability-page', url = 'https://www.alpinetrek.co.uk/climate-neutral/' },
+  # { domain = 'valleytrek.co.uk', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.nl', doctype = 'sustainability-page', url = 'https://www.hillbob.nl/klimaatneutraliteit/' },
-  # { domain = 'hillbob.nl', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'hillbob.nl', doc_type = 'sustainability-page', url = 'https://www.hillbob.nl/klimaatneutraliteit/' },
+  # { domain = 'hillbob.nl', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'alpine.fr', doctype = 'sustainability-page', url = 'https://www.alpine.fr/carbone-neutre/' },
-  # { domain = 'alpine.fr', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'alpine.fr', doc_type = 'sustainability-page', url = 'https://www.alpine.fr/carbone-neutre/' },
+  # { domain = 'alpine.fr', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.eu', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
-  # { domain = 'hillbob.eu', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'hillbob.eu', doc_type = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  # { domain = 'hillbob.eu', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.at', doctype = 'sustainability-page', url = 'https://www.hillbob.at/klimaneutral/' },
-  # { domain = 'hillbob.at', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'hillbob.at', doc_type = 'sustainability-page', url = 'https://www.hillbob.at/klimaneutral/' },
+  # { domain = 'hillbob.at', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.ch', doctype = 'sustainability-page', url = 'https://www.hillbob.ch/klimaneutral/', aliases = [
+  { domain = 'hillbob.ch', doc_type = 'sustainability-page', url = 'https://www.hillbob.ch/klimaneutral/', aliases = [
     "hill-bob.ch",
     "www.hilbob.ch",
     "www.hill-bob.ch",
   ] },
-  # { domain = 'hillbob.ch', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  # { domain = 'hillbob.ch', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.dk', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
-  # { domain = 'hillbob.dk', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'hillbob.dk', doc_type = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  # { domain = 'hillbob.dk', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.se', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
-  # { domain = 'hillbob.se', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'hillbob.se', doc_type = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  # { domain = 'hillbob.se', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.no', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
-  # { domain = 'hillbob.no', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'hillbob.no', doc_type = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  # { domain = 'hillbob.no', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.fi', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
-  # { domain = 'hillbob.fi', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'hillbob.fi', doc_type = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  # { domain = 'hillbob.fi', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.it', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
-  # { domain = 'hillbob.it', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'hillbob.it', doc_type = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  # { domain = 'hillbob.it', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.es', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
-  # { domain = 'hillbob.es', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'hillbob.es', doc_type = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  # { domain = 'hillbob.es', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hbcdn.com', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
-  # { domain = 'hbcdn.com', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  { domain = 'hbcdn.com', doc_type = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  # { domain = 'hbcdn.com', doc_type = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
 ]

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -63,7 +63,7 @@ def test_hitting_validate_url_endpoint_with_via_delegation(live_server):
     res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
 
     assert res.status_code == 200
-    actual_provider_domain = res.json()["data"]["org"]["credentials"][0]["domain"]
+    actual_provider_domain = res.json()["data"]["org"]["disclosures"][0]["domain"]
     assert actual_provider_domain == "managed-service.carbontxt.org"
 
 
@@ -81,7 +81,7 @@ def test_hitting_validate_url_endpoint_with_txt_delegation(live_server):
     # https://used-in-tests.carbontxt.org/carbon.txt
 
     # TODO: Should we serve a different error here, like a 40x?
-    # actual_provider_domain = res.json()["data"]["org"]["credentials"][0]["domain"]
+    # actual_provider_domain = res.json()["data"]["org"]["disclosures"][0]["domain"]
     # assert actual_provider_domain == "managed-service.carbontxt.org"
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -12,10 +12,10 @@ class TestParseCarbonTxt:
         parsed = parser.parse_toml(minimal_carbon_txt_org, logs=[])
         assert "upstream" in parsed
         assert "org" in parsed
-        assert "providers" in parsed["upstream"]
-        assert "credentials" in parsed["org"]
-        assert len(parsed["upstream"]["providers"]) == 0
-        assert len(parsed["org"]["credentials"]) == 1
+        assert "services" in parsed["upstream"]
+        assert "disclosures" in parsed["org"]
+        assert len(parsed["upstream"]["services"]) == 0
+        assert len(parsed["org"]["disclosures"]) == 1
 
     def test_parse_toml_short(self, shorter_carbon_txt_string):
         """
@@ -25,10 +25,10 @@ class TestParseCarbonTxt:
         assert parsed
         assert "upstream" in parsed
         assert "org" in parsed
-        assert "providers" in parsed["upstream"]
-        assert "credentials" in parsed["org"]
-        assert len(parsed["upstream"]["providers"]) == 2
-        assert len(parsed["org"]["credentials"]) == 1
+        assert "services" in parsed["upstream"]
+        assert "disclosures" in parsed["org"]
+        assert len(parsed["upstream"]["services"]) == 2
+        assert len(parsed["org"]["disclosures"]) == 1
 
     def test_parse_toml_minimal(self, minimal_carbon_txt_org):
         """
@@ -38,16 +38,16 @@ class TestParseCarbonTxt:
         assert parsed
         assert "upstream" in parsed
         assert "org" in parsed
-        assert "providers" in parsed["upstream"]
-        assert "credentials" in parsed["org"]
-        assert len(parsed["upstream"]["providers"]) == 0
-        assert len(parsed["org"]["credentials"]) == 1
+        assert "services" in parsed["upstream"]
+        assert "disclosures" in parsed["org"]
+        assert len(parsed["upstream"]["services"]) == 0
+        assert len(parsed["org"]["disclosures"]) == 1
         assert (
-            parsed["org"]["credentials"][0]["domain"] == "used-in-tests.carbontxt.org"
+            parsed["org"]["disclosures"][0]["domain"] == "used-in-tests.carbontxt.org"
         )
-        assert parsed["org"]["credentials"][0]["doctype"] == "sustainability-page"
+        assert parsed["org"]["disclosures"][0]["doc_type"] == "sustainability-page"
         assert (
-            parsed["org"]["credentials"][0]["url"]
+            parsed["org"]["disclosures"][0]["url"]
             == "https://used-in-tests.carbontxt.org/our-climate-record"
         )
 

--- a/tests/test_processor_csrd.py
+++ b/tests/test_processor_csrd.py
@@ -1,14 +1,12 @@
-import pytest
 import pathlib
-from carbon_txt import processors  # type: ignore
 
-
+import pytest
 from arelle import (  # type: ignore
     ModelXbrl,
 )
-
-
 from structlog import get_logger
+
+from carbon_txt import processors  # type: ignore
 
 logger = get_logger()
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -5,7 +5,7 @@ from pydantic import ValidationError
 
 
 class TestOrganisation:
-    def test_organisation_required_credentials(self):
+    def test_organisation_required_disclosures(self):
         """ """
         with pytest.raises(ValidationError):
-            Organisation(credentials=[])
+            Organisation(disclosures=[])


### PR DESCRIPTION
Closes #62 

---

This pull request includes several changes to update terminology and improve code consistency in the `carbon_txt` project. The main changes involve renaming certain terms and updating the corresponding code and documentation.

Terminology updates:

* [`docs/adrs/01_adding_plugins_with_pluggy.md`](diffhunk://#diff-daf3404006eba8e6351e79286c8d3f054430adcc3ab66dab2e5ee9d0e1d078bcL133-R133): Changed `document.doctype` to `document.doc_type`.
* [`docs/extending_with_plugins.md`](diffhunk://#diff-4ca6ceedb0aeecf9fd64bdf50b4f586a58a2ac2694bf7fe411a48a0989e2e5b7L102-R103): Updated `Credential` to `Disclosure` and `doctype` to `doc_type`.
* [`src/carbon_txt/schemas.py`](diffhunk://#diff-b1c1bcdab791fdd66e23a8b693ca43c73de6d260cd115b4be6d44811d5b1c711L6-R30): Renamed `Provider` to `Service`, `Credential` to `Disclosure`, and `doctype` to `doc_type`. [[1]](diffhunk://#diff-b1c1bcdab791fdd66e23a8b693ca43c73de6d260cd115b4be6d44811d5b1c711L6-R30) [[2]](diffhunk://#diff-b1c1bcdab791fdd66e23a8b693ca43c73de6d260cd115b4be6d44811d5b1c711L39-R60)
* [`src/carbon_txt/process_csrd_document.py`](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52L2-R2): Updated references from `Credential` to `Disclosure` and `doctype` to `doc_type`. [[1]](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52L2-R2) [[2]](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52L27-R27) [[3]](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52L40-R40) [[4]](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52L68-R68)

Code and test updates:

* `tests/conftest.py`, `tests/fixtures/`, `tests/test_api_external.py`, `tests/test_parsers.py`: Updated test cases and fixture files to reflect the new terminology. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L18-R21) [[2]](diffhunk://#diff-b0a6c1a0e61d12839768ec160704af19d882b22272593ce7c037188e60c144c5L2-R2) [[3]](diffhunk://#diff-bd16ad0c63e458bf97b7ee0bed82ce9c99a4a586914bec6c01d305ecb372495cL2-R61) [[4]](diffhunk://#diff-86f83c281574af3b5081f13775baccb0f159d315c808203bd55d7f33d8b353b1L66-R66) [[5]](diffhunk://#diff-5645526b039ef48571bc3d999640658547261a886bc526434a591bebc99dfcebL15-R18)