### PR TITLE
Tidy up logging so it's in one file

### DIFF
--- a/src/carbon_txt/log_config.py
+++ b/src/carbon_txt/log_config.py
@@ -1,0 +1,126 @@
+import logging
+import logging.config
+import structlog
+
+# to get logging working consistently the Django webserver and the CLI
+# we need to configure both:
+#
+# 1. structlog, for our code, AND
+# 2. configure the default logging.logger libraries
+
+
+shared_processors = [
+    structlog.contextvars.merge_contextvars,
+    structlog.processors.TimeStamper(fmt="iso"),
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.PositionalArgumentsFormatter(),
+    structlog.processors.StackInfoRenderer(),
+    structlog.processors.format_exc_info,
+    structlog.processors.UnicodeDecoder(),
+]
+
+# https://www.structlog.org/en/stable/standard-library.html
+# configure here sets up our structlog logger, so we can
+# use structlog.get_logger() to get a logger that logs the way we want
+structlog.configure(
+    processors=shared_processors
+    + [
+        structlog.stdlib.filter_by_level,
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    ],  # type: ignore
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    cache_logger_on_first_use=True,
+    # we can use the make_filtering_bound_logger method to filter out
+    # log messages before they make it to a processor
+    wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG),
+)
+
+logger = structlog.get_logger()
+
+
+# We now need to configure the default logging that uses logging.logger,
+# so that `logging.getLogger()` follows the same kinds of formatting rules.
+# We set up our LOGGING dict, and then load it in wuth the dictConfig() method
+
+# we define how django loggers should work here too, as we Django needs to load
+# this in too, upon setup
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "json_formatter": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.JSONRenderer(),
+            "foreign_pre_chain": shared_processors,
+        },
+        "plain_console": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.dev.ConsoleRenderer(),
+            # this is required to add the log levels and timestamps
+            "foreign_pre_chain": shared_processors,
+        },
+        "key_value": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.KeyValueRenderer(
+                key_order=["timestamp", "level", "event", "logger"]
+            ),
+            "foreign_pre_chain": shared_processors,
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "plain_console",
+        },
+        "nullhandler": {
+            "class": "logging.NullHandler",
+        },
+    },
+    "loggers": {
+        # set our default logger
+        "root": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": True,
+        },
+        "django": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": True,
+        },
+        "django.request": {
+            "level": "INFO",
+            "handlers": ["console"],
+        },
+        # if we have django_structlog logging requests, then django
+        # server can be seen as redundant. So we use the nullhandler
+        "django.server": {
+            "formatter": "plain_console",
+            "level": "INFO",
+            "handlers": ["nullhandler"],
+        },
+        "django_structlog": {
+            "level": "INFO",
+            "handlers": ["console"],
+        },
+        "django.utils.autoreload": {
+            "level": "INFO",
+            "handlers": ["console"],
+        },
+        "httpx": {
+            "level": "WARNING",
+        },
+        "httpcore": {
+            "level": "WARNING",
+        },
+        "carbon_txt": {
+            "level": "WARNING",
+        },
+    },
+}
+
+
+# configure logging with the massive logging dict
+logging.config.dictConfig(LOGGING)

--- a/src/carbon_txt/validators.py
+++ b/src/carbon_txt/validators.py
@@ -15,7 +15,6 @@ from .plugins import module_from_path, pm
 file_finder = finders.FileFinder()
 parser = parsers_toml.CarbonTxtParser()
 
-
 logger = structlog.get_logger()
 
 
@@ -62,12 +61,17 @@ class CarbonTxtValidator:
         provided plugin directory `plugins_dir`, and activating any plugins
         """
 
-        logger.info(
+        logger.debug(
             f"plugins_dir: {plugins_dir}",
         )
-        logger.info(
+        logger.debug(
             f"active_plugins {active_plugins}",
         )
+
+        # breakpoint()
+
+        # make sure the plugins list is empty before we start
+
         if plugins_dir is not None:
             self.plugins_dir = plugins_dir
             plugins_path = pathlib.Path(plugins_dir).resolve()
@@ -93,7 +97,7 @@ class CarbonTxtValidator:
                     logger.warning(f"Plugin already registered: {mod}")
                     pass
 
-        logger.debug(f"\nPLUGINS: {pm.get_plugins()}\n")
+        logger.debug(f"PLUGINS: {pm.get_plugins()}\n")
 
     def _append_document_processing(
         self, validation_results: schemas.CarbonTxtFile
@@ -136,6 +140,12 @@ class CarbonTxtValidator:
                         document_processing_results[plugin_name] = document_results
 
         return document_processing_results
+
+    def list_plugins(self) -> list:
+        """
+        Return a list of all registered plugins
+        """
+        return [*pm.get_plugins()]
 
     def validate_contents(self, contents: str) -> ValidationResult:
         """

--- a/src/carbon_txt/web/api.py
+++ b/src/carbon_txt/web/api.py
@@ -2,14 +2,14 @@ import pydantic
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse  # noqa
 from ninja import NinjaAPI, Schema
-from structlog import get_logger
+import structlog
 
 from .. import exceptions, finders, schemas, validators  # noqa
 
 file_finder = finders.FileFinder()
 
 
-logger = get_logger()
+logger = structlog.get_logger()
 
 # Initialize the NinjaAPI with OpenAPI documentation details
 ninja_api = NinjaAPI(

--- a/src/carbon_txt/web/config/settings/base.py
+++ b/src/carbon_txt/web/config/settings/base.py
@@ -21,75 +21,11 @@ from carbon_txt.exceptions import InsecureKeyException
 from carbon_txt.plugins import DEFAULT_PLUGINS as DEFAULT_CARBON_TXT_PLUGINS
 
 
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "json_formatter": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.processors.JSONRenderer(),
-        },
-        "plain_console": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(),
-        },
-        "key_value": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.processors.KeyValueRenderer(
-                key_order=["timestamp", "level", "event", "logger"]
-            ),
-        },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "plain_console",
-        },
-        "nullhandler": {
-            "class": "logging.NullHandler",
-        },
-    },
-    "loggers": {
-        # set our default logger
-        "root": {
-            "handlers": ["console"],
-            "level": "INFO",
-            "propagate": True,
-        },
-        "django_structlog": {
-            "level": "INFO",
-        },
-        "httpx": {
-            "level": "WARNING",
-        },
-        "httpcore": {
-            "level": "INFO",
-        },
-        "carbon_txt": {
-            "level": "INFO",
-        },
-    },
-}
-
-structlog.configure(
-    processors=[
-        structlog.contextvars.merge_contextvars,
-        structlog.stdlib.filter_by_level,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        structlog.processors.UnicodeDecoder(),
-        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-    ],
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    cache_logger_on_first_use=True,
-)
+# looking for the LOGGING config? See carbon_txt.log_config, for the
+# logging configuration that is used by the rest of the application
+from carbon_txt.log_config import LOGGING  # noqa
 
 logger = structlog.get_logger()
-
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent.parent


### PR DESCRIPTION
This PR revisits how we handle logging, so it's controlled from one file, and also documents the use of both

1. structlog in used in our first-party code, and the use of `structlog.get_logger()`
2. the use of garden-variety logging in dependencies, that use the `logging.getLogger()` approach to create a logger

---

This pull request includes several changes to the `src/carbon_txt` project, focusing on logging improvements, CLI enhancements, and code cleanup. The most important changes include the addition of a new logging configuration, updates to the CLI for better plugin management, and various code improvements for clarity and functionality.

### Logging Improvements:
* Added a comprehensive logging configuration in `src/carbon_txt/log_config.py` to standardize logging across the application. This includes setting up `structlog` and configuring default loggers for Django and other components.
* Updated references to the logging configuration in `src/carbon_txt/web/config/settings/base.py` to use the new `carbon_txt.log_config` module.

### CLI Enhancements:
* Added a new CLI command `plugins` to list active plugins, providing users with better visibility and control over plugin management.
* Improved the `create_validator` function by adding a docstring and fixing the assignment of `plugins_dir` from environment variables. [[1]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaL33-R39) [[2]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaL47-R52)

### Code Cleanup:
* Removed unused imports and restructured import statements for better readability in `src/carbon_txt/cli.py`.
* Added debug logging and a method to list plugins in `src/carbon_txt/validators.py` to facilitate debugging and improve code clarity. [[1]](diffhunk://#diff-ee4638d5f5c485cd75d48d52d7f2d32e24512f6ee6d1455711fa44f87d0b7a09L65-R74) [[2]](diffhunk://#diff-ee4638d5f5c485cd75d48d52d7f2d32e24512f6ee6d1455711fa44f87d0b7a09R144-R149)

### Miscellaneous:
* Added a "Hello, World" log message to the CLI to verify logger setup.
* Cleaned up commented-out code and added minor formatting improvements in various files. [[1]](diffhunk://#diff-a6ba177b10e6c53969a525a3552a70ac7f0b2b0d03a736e7fa7e76fbd3eaddbaR133-R146) [[2]](diffhunk://#diff-ee4638d5f5c485cd75d48d52d7f2d32e24512f6ee6d1455711fa44f87d0b7a09L96-R100)