### PR TITLE
Make our CSRD processing code easier to make plugins from

### DIFF
--- a/src/carbon_txt/process_csrd_document.py
+++ b/src/carbon_txt/process_csrd_document.py
@@ -1,6 +1,6 @@
 from .hookspecs import hookimpl
-from .schemas import CarbonTxtFile, Disclosure
-from .processors import CSRDProcessor
+from .schemas import Disclosure
+from .processors import GreenwebCSRDProcessor
 import logging
 from typing import Optional
 
@@ -25,11 +25,10 @@ plugin_name = "csrd_greenweb"
 @hookimpl
 def process_document(
     document: Disclosure,
-    parsed_carbon_txt_file: Optional[CarbonTxtFile],
     logs: Optional[list],
 ):
     """
-    Listen for documents linked in the carbon.txt file that are ixbrl CSRD reports,
+    Listen for documents linked in the carbon.txt file that are iXBRL CSRD reports,
     and use Arelle to parse them for selected datapoints
     """
     log_safely(
@@ -44,12 +43,9 @@ def process_document(
         )
 
         try:
-            processor = CSRDProcessor(document.url)
+            processor = GreenwebCSRDProcessor(report_url=document.url)
 
-            chosen_datapoints = [
-                value.replace("esrs:", "")
-                for value in CSRDProcessor.esrs_datapoints.keys()
-            ]
+            chosen_datapoints = processor.local_datapoint_codes
 
             results = processor.get_esrs_datapoint_values(chosen_datapoints)
 

--- a/src/carbon_txt/web/config/settings/base.py
+++ b/src/carbon_txt/web/config/settings/base.py
@@ -18,12 +18,11 @@ import sentry_sdk
 import structlog
 
 from carbon_txt.exceptions import InsecureKeyException
-from carbon_txt.plugins import DEFAULT_PLUGINS as DEFAULT_CARBON_TXT_PLUGINS
-
 
 # looking for the LOGGING config? See carbon_txt.log_config, for the
 # logging configuration that is used by the rest of the application
 from carbon_txt.log_config import LOGGING  # noqa
+from carbon_txt.plugins import DEFAULT_PLUGINS as DEFAULT_CARBON_TXT_PLUGINS
 
 logger = structlog.get_logger()
 
@@ -49,10 +48,13 @@ dotenv_file = pathlib.Path(env("ENV_PATH")).absolute()
 if dotenv_file.exists():
     env.read_env(env("ENV_PATH"))
 
-settings_module = os.getenv("DJANGO_SETTINGS_MODULE")
+settings_module = os.getenv("DJANGO_SETTINGS_MODULE", "")
+
+
+in_production = "settings.production" in settings_module
 
 # if we are in a production environment, we need to ensure that the SECRET_KEY is set
-if env("SECRET_KEY") == DEFAULT_SECRET_KEY and "settings.production" in settings_module:
+if env("SECRET_KEY") == DEFAULT_SECRET_KEY and in_production:
     raise InsecureKeyException(
         "You are using the default SECRET_KEY value in a production environment. "
         "Please set a proper SECRET_KEY, via the SECRET_KEY environment variable."
@@ -74,7 +76,7 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS: list[str] = []
 
 
 # Application definition


### PR DESCRIPTION
This PR is the result of me rethinking how we use the Arelle XBRL parsing library in the carbon.txt validator, with a view to making it much easier to build plugins that query other CSRD datapoints that might be of interest.

The big change is that rather than there being a a single CSRD processor which contains a bunch of hard coded datapoints (i.e. "our" datapoints for tracking green energy), we:

1. move much of logic of using an XBRL parsing library into the `ArelleProcessor` which is a simplified wrapper around the Arelle's Python API
2. create a new `GreenwebCSRDProcessor` class that makes much more explicit use of the methods offered by the  `ArelleProcessor` directly. We're only really querying for a few datapoints, so we don't really need / want full access to what Arelle offers us.
3. defines a `Protocol` for other Processors to satisfy, in order to be considered compatible with this use of the logic encapsulated in the ArelleProcessor.

The thinking here is that others who want to make use of the CSRD parsing language need only make a relatively small class similar to the `GreenwebCSRDProcessor` themselves, that also consumes the `ArelleProcessor` methods directly.

I've used a Protocol and composition here instead of inheritance -  the intention here is that ultimately it's better to have a bit of upfront friction to create a new class yourself, that you understand fully, and uses a small, well defined API on a separate object, than to subclass something you don't fully understand, and then have to guess at what methods might be "yours" vs in the class hierarchy.

Anyway - the ML generated summary is below too.
---

This pull request includes significant changes to the `carbon_txt` module, particularly focusing on refactoring the CSRD processing classes and updating related tests. The main changes involve replacing the `CSRDProcessor` with the new `GreenwebCSRDProcessor` and `ArelleProcessor`, as well as introducing a protocol for CSRD processing plugins.

### Refactoring and Class Renaming:
* [`src/carbon_txt/process_csrd_document.py`](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52L2-R3): Replaced `CSRDProcessor` with `GreenwebCSRDProcessor` for processing CSRD documents. [[1]](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52L2-R3) [[2]](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52L47-R48)
* [`src/carbon_txt/processors.py`](diffhunk://#diff-52d4333509fb9634b01e7493d3fb0dddbdb587725f382cca68cab31a064854c1L34-R60): Renamed `CSRDProcessor` to `ArelleProcessor`, and introduced `GreenwebCSRDProcessor` and `CSRDProcessorProtocol` to handle CSRD processing with a more modular approach. [[1]](diffhunk://#diff-52d4333509fb9634b01e7493d3fb0dddbdb587725f382cca68cab31a064854c1L34-R60) [[2]](diffhunk://#diff-52d4333509fb9634b01e7493d3fb0dddbdb587725f382cca68cab31a064854c1R162-R292)

### Code Simplification and Cleanup:
* Removed unnecessary logging setup and cleaned up the initialization process in `ArelleProcessor`. [[1]](diffhunk://#diff-52d4333509fb9634b01e7493d3fb0dddbdb587725f382cca68cab31a064854c1L86-L96) [[2]](diffhunk://#diff-52d4333509fb9634b01e7493d3fb0dddbdb587725f382cca68cab31a064854c1L106-R115)

### Test Updates:
* Updated tests to use `GreenwebCSRDProcessor` and `ArelleProcessor` instead of `CSRDProcessor`. [[1]](diffhunk://#diff-d5b371c3981bfbca90ec6d6fd4748c742c5d8585dcb42a8937461ae388375833L39-R40) [[2]](diffhunk://#diff-d5b371c3981bfbca90ec6d6fd4748c742c5d8585dcb42a8937461ae388375833L51-R56) [[3]](diffhunk://#diff-d5b371c3981bfbca90ec6d6fd4748c742c5d8585dcb42a8937461ae388375833L69-R78) [[4]](diffhunk://#diff-d5b371c3981bfbca90ec6d6fd4748c742c5d8585dcb42a8937461ae388375833L84-R89) [[5]](diffhunk://#diff-d5b371c3981bfbca90ec6d6fd4748c742c5d8585dcb42a8937461ae388375833L93-R109) [[6]](diffhunk://#diff-d5b371c3981bfbca90ec6d6fd4748c742c5d8585dcb42a8937461ae388375833L129-R139) [[7]](diffhunk://#diff-d5b371c3981bfbca90ec6d6fd4748c742c5d8585dcb42a8937461ae388375833L141-R151)

### Configuration Adjustments:
* Minor adjustments to `src/carbon_txt/web/config/settings/base.py` to improve readability and ensure proper environment variable handling. [[1]](diffhunk://#diff-ccf5495a22ae8d4d5794a784e145dcebd0b028815a5e8ac2fe80dac75af7412dL21-R25) [[2]](diffhunk://#diff-ccf5495a22ae8d4d5794a784e145dcebd0b028815a5e8ac2fe80dac75af7412dL52-R57) [[3]](diffhunk://#diff-ccf5495a22ae8d4d5794a784e145dcebd0b028815a5e8ac2fe80dac75af7412dL77-R79)