### PR TITLE
Allow our validator to accept strings and lists of strings when listing services

### DIFF
--- a/src/carbon_txt/schemas.py
+++ b/src/carbon_txt/schemas.py
@@ -17,7 +17,7 @@ class Service(BaseModel):
     # javascript prefers camelCase
     # but kebab-case is arguable more common in URLS
     # how do we support this?
-    service_type: Optional[List[str]] = None
+    service_type: Optional[List[str]] | str = None
 
 
 class Disclosure(BaseModel):

--- a/tests/fixtures/regression.strings-or-lists.carbon.txt.toml
+++ b/tests/fixtures/regression.strings-or-lists.carbon.txt.toml
@@ -1,0 +1,23 @@
+# This is an sample file to catch the bug listed in issue 8,
+# when started listing services as strings, not lists of strings.
+# we cover both cases, because there are
+# https://github.com/thegreenwebfoundation/carbon-txt-site/issues/8
+[org]
+disclosures = [
+	{ doc_type = "web-page", url = "https://mycompany.com/sustainability", domain = "mycompany.com" },
+	{ doc_type = "annual-report", url = "https://mycompany.com/carbon-emissions-2022.pdf", domain = "mycompany.com" },
+]
+
+[upstream]
+services = [
+	{ domain = "cloud.google.com", service_type = "shared-hosting" },
+	{ domain = "aws.amazon.com", service_type = "cdn" },
+
+	# we should also support lists of strings like so, when a single
+	# provider offers multiple services.
+	# i.e., somethign like
+	# { domain = "some-other.provider.com", service_type = [
+	# 	"managed-database",
+	# 	"virtual-private-servers",
+	# ] },
+]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,5 +1,6 @@
 from carbon_txt import validators  # type: ignore
 import pytest
+import pathlib
 
 
 class TestCarbonTxtValidator:
@@ -62,4 +63,22 @@ class TestCarbonTxtValidator:
 
         assert res.result
         assert not res.document_results
+        assert not res.exceptions
+
+    def test_validate_file_output_from_svelte_validator(self):
+        """
+        This should show a failure safely, as the URL is not reachable
+        """
+        validator = validators.CarbonTxtValidator()
+
+        # this is the expected output from the svelte carbon.txt builder
+        svelte_output = pathlib.Path(
+            "tests/fixtures/regression.strings-or-lists.carbon.txt.toml"
+        )
+
+        path_to_carbon_txt = str(svelte_output.absolute())
+
+        res = validator.validate_url(path_to_carbon_txt)
+
+        assert res.result
         assert not res.exceptions


### PR DESCRIPTION
This PR is added to fix the issue raised last week here:

https://github.com/thegreenwebfoundation/carbon-txt-site/issues/8

(Note: the issue might have been moved to a different repo - I'll try to update the link if so)
----


This pull request includes several changes to improve the handling of service types and validate file outputs. The most important changes include updating the `service_type` field to support both strings and lists, adding a new test fixture to catch a specific bug, and introducing a new validation test.

Updates to `service_type` handling:

* [`src/carbon_txt/schemas.py`](diffhunk://#diff-b1c1bcdab791fdd66e23a8b693ca43c73de6d260cd115b4be6d44811d5b1c711L20-R20): Modified the `service_type` field in the `Service` class to accept both a list of strings and a single string.

New test fixtures:

* [`tests/fixtures/regression.strings-or-lists.carbon.txt.toml`](diffhunk://#diff-c0d906fbdfd1f6882303fe0f73d80d611c577ef502024c3200bfa6cecc8d4298R1-R23): Added a new test fixture file to catch the bug related to listing services as strings instead of lists of strings.

Validation tests:

* [`tests/test_validators.py`](diffhunk://#diff-6ab916975a15e776ca67e412324892450797a072021e31b5485e82172e167b04R3): Imported `pathlib` to handle file paths in tests.
* [`tests/test_validators.py`](diffhunk://#diff-6ab916975a15e776ca67e412324892450797a072021e31b5485e82172e167b04R67-R84): Added a new test method `test_validate_file_output_from_svelte_validator` to validate the output from the svelte carbon.txt builder and ensure it handles unreachable URLs safely.