### PR TITLE
Use http and dns mocks in test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ This will start an local server that by default listens on http://127.0.0.1:8000
 
 ![Screenshot of the validator API](docs/img/plugins-apidocs-example.png)
 
-### Further guidance on usage 
+### Further guidance on usage
 
 Please see the [dedicated documentation site for the validator](https://carbon-txt-validator.readthedocs.io/en/latest/) for details about how the validator works, and how to install it, extend it, and to deploy it.
 
 # Installation
 
 > [!TIP]
-> See more detailed [guidance on installation on the dedicated valiator docs site](https://carbon-txt-validator.readthedocs.io/en/latest/installation.html). 
+> See more detailed [guidance on installation on the dedicated valiator docs site](https://carbon-txt-validator.readthedocs.io/en/latest/installation.html).
 
 ## Using `pip`
 
@@ -134,7 +134,7 @@ We are always open for discussions about how people can contribute back to the d
 
 The Green Web Foundation offers commercial consulting on:
 
-- using the carbon.txt validator to parse and process sustainability disclosures online, 
+- using the carbon.txt validator to parse and process sustainability disclosures online,
 - disclosing this information in a way that validators can pick up, by implementing carbon.txt files
 - requesting disclosures from suppliers using the carbon.txt convention
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,6 @@ dev-dependencies = [
     "twine>=5.1.1",
     "pytest-coverage>=0.0",
     "marimo>=0.9.23",
+    "pytest-httpx>=0.34.0",
+    "pytest-mock>=3.14.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 import pytest
 import pathlib
 
-
 import structlog
 
 logger = structlog.get_logger()
+
+pytest_plugins = ["http_mocks"]
 
 
 @pytest.fixture

--- a/tests/http_mocks.py
+++ b/tests/http_mocks.py
@@ -1,0 +1,179 @@
+"""
+This module contains pytest fixtures which set up mocks for HTTP and DNS requests
+needed when testing the carbon.txt finder: This allows us to make sure our tests
+are decoupled from any real infrastructure, and that they can be run without an
+internet connection. If you are writing a test which needs to exercise the carbon.txt
+finder, you can rely on one of these fixtures, like so:
+
+def test_finder(mocked_carbon_text_url):
+    response = httpx.get(mocked_carbon_text_url)
+    assert(response.status_code == 200)
+
+The available mocks are as follows:
+    - mocked_carbon_txt_url
+        (url with path to carbon.txt, returns valid TOML with 200 response)
+    - mocked_cabon_txt_domain
+        (domain only, valid TOML, 200 response)
+    - mocked_http_delegating_carbon_txt_url
+        (delegates to other domain with Via header, other domain returns
+         valid TOML with 200 resposne)
+    - mocked_dns_delegating_carbon_txt_url
+        (redirects to other domain wtih DNS TXT record, other domain returns
+         valid TOML with 200 response)
+    - mocked_404_carbon_txt_url
+        (No delegation, request for carbon.txt returns 404 status.)
+
+Why do we provide these fixtures, instead of just setting up the mocks in the tests themselves? Firstly, because, while it might appear a bit "magic", it makes the tests themselves smaller and easier to follow, and avoids repetition of setup code for common test scenarios. Secondly, and more importantly, however, it allows us to mock HTTP request when running the api tests with pytest-django: the mocks must be set up *before* the test itself, or they won't be available in the live_server that pytest-django provides.
+
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+
+# These annotations ensure that httpx_mock does not mock any *other* http requests:
+# In particular this is important for API integration tests as we want to make requests
+# from the API itself.
+@pytest.fixture(
+    params=[
+        pytest.param(
+            "",
+            marks=pytest.mark.httpx_mock(
+                should_mock=lambda request: request.url.host.endswith(
+                    "withcarbontxt.example.com"
+                )
+            ),
+        )
+    ]
+)
+def mocked_carbon_txt_domain(minimal_carbon_txt_org, httpx_mock) -> str:
+    """
+    Return a valid carbon.txt with a 200 response, and provide
+    the domain name only to the test
+    """
+    domain = "withcarbontxt.example.com"
+    httpx_mock.add_response(
+        url=f"https://{domain}/carbon.txt",
+        content=minimal_carbon_txt_org,
+        status_code=200,
+        is_reusable=True,
+        is_optional=True,
+    )
+    return domain
+
+
+@pytest.fixture
+def mocked_carbon_txt_url(mocked_carbon_txt_domain) -> str:
+    """
+    Return a valid carbon.txt with a 200 response, and provide
+    the full url to carbon.txt to the test
+    """
+    return f"https://{mocked_carbon_txt_domain}/carbon.txt"
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            "",
+            marks=pytest.mark.httpx_mock(
+                should_mock=lambda request: request.url.host.endswith(
+                    "withcarbontxt.example.com"
+                )
+            ),
+        )
+    ]
+)
+def mocked_http_delegating_carbon_txt_url(minimal_carbon_txt_org, httpx_mock) -> str:
+    """
+    Return a url which delegates carbon.txt using an HTTP via header,
+    and provide the full URL to the test.
+    Ensure the delegated URL responds with a valid carbon.txt and a 200 response.
+    """
+    website_url = "https://delegating.withcarbontxt.example.com/carbon.txt"
+    managed_service_url = "https://delegate.withcarbontxt.example.com/carbon.txt"
+    domain_hash_check = "deadb33fdeadf00d"  # TODO: This will need to be generated properly once verification is in place
+    httpx_mock.add_response(
+        url=website_url,
+        status_code=204,
+        content="",
+        headers={"Via": f"1.1 {managed_service_url} {domain_hash_check}"},
+        is_reusable=True,
+    )
+    httpx_mock.add_response(
+        url=managed_service_url,
+        status_code=200,
+        content=minimal_carbon_txt_org,
+        is_reusable=True,
+    )
+    return website_url
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            "",
+            marks=pytest.mark.httpx_mock(
+                should_mock=lambda request: request.url.host.endswith(
+                    "withcarbontxt.example.com"
+                ),
+            ),
+        )
+    ]
+)
+def mocked_dns_delegating_carbon_txt_url(
+    minimal_carbon_txt_org, mocker, httpx_mock
+) -> str:
+    """
+    Return a url which delegates carbon.txt using a DNS TXT record,
+    and provide the full URL to the test.
+    Ensure the delegated URL responds with a valid carbon.txt and a 200 response.
+    """
+    website_url = "https://delegating.withcarbontxt.example.com/carbon.txt"
+    managed_service_url = "https://delegate.withcarbontxt.example.com/carbon.txt"
+    domain_hash_check = "deadb33fdeadf00d"  # TODO: This will need to be generated properly once verification is in place
+    record = MagicMock()
+    record.to_text.return_value = (
+        f'"carbon-txt={managed_service_url} {domain_hash_check}"'
+    )
+
+    def dns_lookup_side_effect(domain, record_type):
+        if domain == "delegating.withcarbontxt.example.com":
+            return [record]
+        else:
+            return []
+
+    mocker.patch("dns.resolver.resolve", side_effect=dns_lookup_side_effect)
+    httpx_mock.add_response(
+        url=managed_service_url,
+        status_code=200,
+        content=minimal_carbon_txt_org,
+        is_reusable=True,
+        is_optional=True,
+    )
+    return website_url
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            "",
+            marks=pytest.mark.httpx_mock(
+                should_mock=lambda request: request.url.host.endswith(
+                    "withcarbontxt.example.com"
+                ),
+            ),
+        )
+    ]
+)
+def mocked_404_carbon_txt_url(httpx_mock) -> str:
+    """
+    Return a 404 error on requests for carbon.txt. Provide the full
+    URL of carbon.txt to the test.
+    """
+    url = "https://non-existent.withcarbontxt.example.com/carbon.txt"
+    httpx_mock.add_response(
+        url=url,
+        status_code=404,
+        is_reusable=True,
+    )
+    return url

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -35,46 +35,54 @@ def test_hitting_validate_endpoint_fail(live_server, url_suffix):
 
 
 @pytest.mark.parametrize("url_suffix", ["", "/"])
-def test_hitting_validate_url_endpoint_ok(live_server, url_suffix):
+def test_hitting_validate_url_endpoint_ok(
+    live_server, url_suffix, mocked_carbon_txt_url
+):
     api_url = f"{live_server.url}/api/validate/url{url_suffix}"
-    data = {"url": "https://aremythirdpartiesgreen.com/carbon.txt"}
+    data = {"url": mocked_carbon_txt_url}
     res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
 
     assert res.status_code == 200
 
 
 @pytest.mark.parametrize("url_suffix", ["", "/"])
-def test_hitting_validate_url_endpoint_fail(live_server, url_suffix):
+def test_hitting_validate_url_endpoint_fail(
+    live_server, url_suffix, mocked_carbon_txt_url
+):
     api_url = f"{live_server.url}/api/validate/url{url_suffix}"
-    data = {"url": "https://aremythirdpartiesgreen.com/carbon.txt"}
+    data = {"url": mocked_carbon_txt_url}
     res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
 
     assert res.status_code == 200
 
 
-def test_hitting_validate_url_endpoint_with_via_delegation(live_server):
+def test_hitting_validate_url_endpoint_with_via_delegation(
+    live_server, mocked_http_delegating_carbon_txt_url
+):
     """
     When we have a carbon.txt url that is delegating to a another server
     using the http 'via' header, does it follow the delegation and return the
     correct response?
     """
     api_url = f"{live_server.url}/api/validate/url/"
-    data = {"url": "https://hosted.carbontxt.org/carbon.txt"}
+    data = {"url": mocked_http_delegating_carbon_txt_url}
     res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
 
     assert res.status_code == 200
     actual_provider_domain = res.json()["data"]["org"]["disclosures"][0]["domain"]
-    assert actual_provider_domain == "managed-service.carbontxt.org"
+    assert actual_provider_domain == "used-in-tests.carbontxt.org"
 
 
-def test_hitting_validate_url_endpoint_with_txt_delegation(live_server):
+def test_hitting_validate_url_endpoint_with_txt_delegation(
+    live_server, mocked_dns_delegating_carbon_txt_url
+):
     """
     When we have a carbon.txt url that is delegating to a another server
     using the DNS txt record, does it follow the delegation and return the
     correct response?
     """
     api_url = f"{live_server.url}/api/validate/url/"
-    data = {"url": "https://delegating-with-txt-record.carbontxt.org/carbon.txt"}
+    data = {"url": mocked_dns_delegating_carbon_txt_url}
     res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
     assert res.status_code == 200
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,27 +12,23 @@ class TestCLI:
     Test our CLI commands RETURN WHT WE
     """
 
-    def test_lookup_domain(self):
+    def test_lookup_domain(self, mocked_carbon_txt_domain):
         """
         Run our CLI to `carbontxt validate domain some-domain.com`, and confirm we
         get back the expected URI, and whether the file was valid.
         """
 
-        result = runner.invoke(
-            app, ["validate", "domain", "used-in-tests.carbontxt.org"]
-        )
+        result = runner.invoke(app, ["validate", "domain", mocked_carbon_txt_domain])
         assert result.exit_code == 0
         assert "used-in-tests.carbontxt.org" in result.stdout
 
-    def test_lookup_file(self):
+    def test_lookup_file(self, mocked_carbon_txt_url):
         """
         Run our CLI to `carbontxt validate file https://some-domain.com/carbon.txt`,
         and confirm we end up with the expected URI, and whether the file was valid.
         """
 
-        result = runner.invoke(
-            app, ["validate", "file", "https://used-in-tests.carbontxt.org/carbon.txt"]
-        )
+        result = runner.invoke(app, ["validate", "file", mocked_carbon_txt_url])
 
         assert result.exit_code == 0
         assert "https://used-in-tests.carbontxt.org" in result.stdout
@@ -63,7 +59,7 @@ class TestCLI:
         assert "CarbonTxtFile" in parsed_schema.get("title")
         assert "$defs" in parsed_schema.keys()
 
-    def test_lookup_domain_with_test_plugin(self):
+    def test_lookup_domain_with_test_plugin(self, mocked_carbon_txt_domain):
         """
         Test that we can run the CLI with a custom plugin directory
         """
@@ -73,7 +69,7 @@ class TestCLI:
             [
                 "validate",
                 "domain",
-                "used-in-tests.carbontxt.org",
+                mocked_carbon_txt_domain,
                 "--plugins-dir",
                 "tests/test_plugins",
             ],

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -5,7 +5,7 @@ from carbon_txt.exceptions import UnreachableCarbonTxtFile  # type: ignore
 
 
 class TestFinder:
-    def test_looking_up_domain_simple(self):
+    def test_looking_up_domain_simple(self, mocked_carbon_txt_domain):
         """
         Look up a domain with a carbon.txt file based on the domain, and return the carbon.txt file URL
         """
@@ -13,43 +13,41 @@ class TestFinder:
         finder = FileFinder()
 
         # Given a domain
-        domain = "used-in-tests.carbontxt.org"
 
         # When we pass a domain
-        result = finder.resolve_domain(domain)
+        result = finder.resolve_domain(mocked_carbon_txt_domain)
 
         # We get back the URI of the carbon.txt file to lookup
-        assert result == f"https://{domain}/carbon.txt"
+        assert result == f"https://{mocked_carbon_txt_domain}/carbon.txt"
 
-    def test_looking_up_uri_simple(self):
+    def test_looking_up_uri_simple(self, mocked_carbon_txt_url):
         """Looking up a domain with a carbon.txt file"""
 
         finder = FileFinder()
 
         # Given a domain with carbon.txt extension
-        carbon_txt_url = "https://used-in-tests.carbontxt.org/carbon.txt"
 
         # When we pass a domain
-        result = finder.resolve_uri(carbon_txt_url)
+        result = finder.resolve_uri(mocked_carbon_txt_url)
 
         # We get back the URI of the carbon.txt file to lookup
-        assert result == carbon_txt_url
+        assert result == mocked_carbon_txt_url
 
-    def test_looking_up_uri_with_delegation_using_dns(self):
+    def test_looking_up_uri_with_delegation_using_dns(
+        self, mocked_dns_delegating_carbon_txt_url
+    ):
         """
         Looking up a carbon.tx file at a domain that has a carbon.txt DNS TXT record
         should delegate us to the correct URL in that TXT record, overriding
         the original URL
         """
         finder = FileFinder()
-        delegating_domain_url = (
-            "https://delegating-with-txt-record.carbontxt.org/carbon.txt"
-        )
-        delegated_domain_url = "https://used-in-tests.carbontxt.org/carbon.txt"
-        result = finder.resolve_uri(delegating_domain_url)
-        assert result == delegated_domain_url
+        result = finder.resolve_uri(mocked_dns_delegating_carbon_txt_url)
+        assert result == "https://delegate.withcarbontxt.example.com/carbon.txt"
 
-    def test_looking_up_uri_with_delegation_using_via(self):
+    def test_looking_up_uri_with_delegation_using_via(
+        self, mocked_http_delegating_carbon_txt_url
+    ):
         """
         Looking up a domain that has a 'via' http header should result
         in us returning the URL in the via header, not the originaL looked up URL
@@ -57,45 +55,37 @@ class TestFinder:
 
         finder = FileFinder()
 
-        # Given our original domain with
-        hosted_domain_url = "https://hosted.carbontxt.org/carbon.txt"
-        via_domain_url = "https://managed-service.carbontxt.org/carbon.txt"
-
         # When we pass a domain
-        result = finder.resolve_uri(hosted_domain_url)
+        result = finder.resolve_uri(mocked_http_delegating_carbon_txt_url)
 
         # We get back the URI of the carbon.txt file to lookup
-        assert result == via_domain_url
+        assert result == "https://delegate.withcarbontxt.example.com/carbon.txt"
 
-    def test_looking_up_uri_with_no_carbon_txt_at_all(self):
+    def test_looking_up_uri_with_no_carbon_txt_at_all(self, mocked_404_carbon_txt_url):
         """
         Looking up a domain that has no carbon.txt file should still return
         the uri to check.
         """
         finder = FileFinder()
-        no_carbon_txt_url = "https://has-no.carbontxt.org/carbon.txt"
 
-        assert finder.resolve_uri(no_carbon_txt_url) == no_carbon_txt_url
+        assert (
+            finder.resolve_uri(mocked_404_carbon_txt_url) == mocked_404_carbon_txt_url
+        )
 
-    def test_fetch_carbon_txt_file(self):
+    def test_fetch_carbon_txt_file(self, mocked_carbon_txt_url):
         finder = FileFinder()
-        no_carbon_txt_url = "https://used-in-tests.carbontxt.org/carbon.txt"
 
-        result = finder.fetch_carbon_txt_file(no_carbon_txt_url)
+        result = finder.fetch_carbon_txt_file(mocked_carbon_txt_url)
         # We get back the carbon.txt file contents which should be a string
         # of at least 180 characters
         assert len(result) > 180
         assert isinstance(result, str)
 
-    @pytest.mark.skip(
-        reason="This test is not yet implemented. Implement it once we add pytest-httpx"
-    )
-    def test_fetch_carbon_txt_file_fails(self):
+    def test_fetch_carbon_txt_file_fails(self, mocked_404_carbon_txt_url):
         """
         When looking up a carbon.txt file fails, we should raise a helpful exception
         """
         finder = FileFinder()
-        no_carbon_txt_url = "https://does-not-matter.carbontxt.org/carbon.txt"
 
         with pytest.raises(UnreachableCarbonTxtFile):
-            finder.fetch_carbon_txt_file(no_carbon_txt_url)
+            finder.fetch_carbon_txt_file(mocked_404_carbon_txt_url)

--- a/uv.lock
+++ b/uv.lock
@@ -138,6 +138,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-coverage" },
     { name = "pytest-django" },
+    { name = "pytest-httpx" },
+    { name = "pytest-mock" },
     { name = "pytest-watch" },
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
@@ -171,6 +173,8 @@ dev = [
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-coverage", specifier = ">=0.0" },
     { name = "pytest-django", specifier = ">=4.9.0" },
+    { name = "pytest-httpx", specifier = ">=0.34.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-watch", specifier = ">=4.2.0" },
     { name = "sphinx", specifier = ">=8.1.3" },
     { name = "sphinx-autobuild", specifier = ">=2024.10.3" },
@@ -1262,8 +1266,6 @@ version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/10/2a30b13c61e7cf937f4adf90710776b7918ed0a9c434e2c38224732af310/psutil-6.1.0.tar.gz", hash = "sha256:353815f59a7f64cdaca1c0307ee13558a0512f6db064e92fe833784f08539c7a", size = 508565 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/2b/f4dea5d993d9cd22ad958eea828a41d5d225556123d372f02547c29c4f97/psutil-6.1.0-cp27-none-win32.whl", hash = "sha256:9118f27452b70bb1d9ab3198c1f626c2499384935aaf55388211ad982611407e", size = 246648 },
-    { url = "https://files.pythonhosted.org/packages/9f/14/4aa97a7f2e0ac33a050d990ab31686d651ae4ef8c86661fef067f00437b9/psutil-6.1.0-cp27-none-win_amd64.whl", hash = "sha256:a8506f6119cff7015678e2bce904a4da21025cc70ad283a53b099e7620061d85", size = 249905 },
     { url = "https://files.pythonhosted.org/packages/01/9e/8be43078a171381953cfee33c07c0d628594b5dbfc5157847b85022c2c1b/psutil-6.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6e2dcd475ce8b80522e51d923d10c7871e45f20918e027ab682f94f1c6351688", size = 247762 },
     { url = "https://files.pythonhosted.org/packages/1d/cb/313e80644ea407f04f6602a9e23096540d9dc1878755f3952ea8d3d104be/psutil-6.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0895b8414afafc526712c498bd9de2b063deaac4021a3b3c34566283464aff8e", size = 248777 },
     { url = "https://files.pythonhosted.org/packages/65/8e/bcbe2025c587b5d703369b6a75b65d41d1367553da6e3f788aff91eaf5bd/psutil-6.1.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9dcbfce5d89f1d1f2546a2090f4fcf87c7f669d1d90aacb7d7582addece9fb38", size = 284259 },
@@ -1454,6 +1456,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/c0/43c8b2528c24d7f1a48a47e3f7381f5ab2ae8c64634b0c3f4bd843063955/pytest_django-4.9.0.tar.gz", hash = "sha256:8bf7bc358c9ae6f6fc51b6cebb190fe20212196e6807121f11bd6a3b03428314", size = 84067 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/fe/54f387ee1b41c9ad59e48fb8368a361fad0600fe404315e31a12bacaea7d/pytest_django-4.9.0-py3-none-any.whl", hash = "sha256:1d83692cb39188682dbb419ff0393867e9904094a549a7d38a3154d5731b2b99", size = 23723 },
+]
+
+[[package]]
+name = "pytest-httpx"
+version = "0.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/08/d0be3fe5645c6cd9396093a9ddf97d60814a3b066fd5b38ddced34a13d14/pytest_httpx-0.34.0.tar.gz", hash = "sha256:3ca4b0975c0f93b985f17df19e76430c1086b5b0cce32b1af082d8901296a735", size = 54108 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/72/7138a0faf5d780d6b9ceedef22da0b66ae8e22a676a12fd55a05c0cdd979/pytest_httpx-0.34.0-py3-none-any.whl", hash = "sha256:42cf0a66f7b71b9111db2897e8b38a903abd33a27b11c48aff4a3c7650313af2", size = 19440 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
 ]
 
 [[package]]


### PR DESCRIPTION
The previous test setup relied upon a number of "known", real, servers having particular test carbon.txt configurations available publicly, which was kinda brittle - both when that configuration changes or the servers go down, but it also means we can't run the test suite while working offline, for instance.

This PR introduces a set of fixtures for various scenarios under test which provide a URL already set up with the correct mocked response, and updates the tests to use them. The fixtures are:

 - `mocked_carbon_txt_domain`
 - `mocked_carbon_txt_url`
 - `mocked_dns_delegating_carbon_txt_url`
 - `mocked_http_delegating_carbon_txt_url`
 - `mocked_404_carbon_txt_url`

Simply use these fixtures in your tests to receive a test URL with the appropriate mocks already set up.


TODO: We still have two test failures, related to handling 404s, but as far as I can tell these are *real* failures -  the `HTTPStatusError`  raised by `httpx ` should be caught, and either an alternative form of validation tried, or an `UnreachableCarbonTxtFile` exception raised. Will discuss with @mrchrisadams and fix before marking this as ready for review!