### PR TITLE
Add domain validation API endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "granian>=1.6.2",
     "httpx>=0.27.2",
     "pluggy>=1.5.0",
+    "pydantic-extra-types>=2.10.3",
     "rich>=13.9.2",
     "sentry-sdk[django]>=2.18.0",
     # faster, but not yet supported by python 3.13 yet

--- a/src/carbon_txt/validators.py
+++ b/src/carbon_txt/validators.py
@@ -23,6 +23,7 @@ class ValidationResult:
     logs: list
     exceptions: list
     result: Optional[schemas.CarbonTxtFile]
+    url: Optional[pydantic.HttpUrl] = None
     document_results: Optional[dict[str, list]] = None
 
 
@@ -221,6 +222,7 @@ class CarbonTxtValidator:
                 logs=self.event_log,
                 exceptions=errors,
                 document_results=document_processing_results or {},
+                url=url,
             )
 
         # the file path is local, but we can't access it
@@ -291,9 +293,9 @@ class CarbonTxtValidator:
         try:
             message = f"Attempting to resolve domain: {domain}"
             self.event_log.append(message)
-            result = file_finder.resolve_domain(domain, logs=self.event_log)
+            resolved_url = file_finder.resolve_domain(domain, logs=self.event_log)
             fetched_file_contents = file_finder.fetch_carbon_txt_file(
-                result, logs=self.event_log
+                resolved_url, logs=self.event_log
             )
             parsed_toml = parser.parse_toml(fetched_file_contents, logs=self.event_log)
             validation_results = parser.validate_as_carbon_txt(
@@ -312,6 +314,7 @@ class CarbonTxtValidator:
                 logs=self.event_log,
                 exceptions=errors,
                 document_results=document_processing_results or {},
+                url=resolved_url,
             )
         except Exception as ex:
             message = f"An unexpected error occurred: {ex}"

--- a/tests/http_mocks.py
+++ b/tests/http_mocks.py
@@ -12,22 +12,36 @@ def test_finder(mocked_carbon_text_url):
 The available mocks are as follows:
     - mocked_carbon_txt_url
         (url with path to carbon.txt, returns valid TOML with 200 response)
-    - mocked_cabon_txt_domain
+    - mocked_carbon_txt_domain
         (domain only, valid TOML, 200 response)
     - mocked_http_delegating_carbon_txt_url
-        (delegates to other domain with Via header, other domain returns
-         valid TOML with 200 resposne)
+        (url with path, delegates to other domain with Via header, other domain
+        returns valid TOML with 200 resposne)
+    - mocked_http_delegating_carbon_txt_domain
+        (domain only, delegates to other domain with Via header, other domain
+        returns valid TOML with 200 response)
     - mocked_dns_delegating_carbon_txt_url
-        (redirects to other domain wtih DNS TXT record, other domain returns
-         valid TOML with 200 response)
+        (url with path, redirects to other domain wtih DNS TXT record, other domain
+        returns valid TOML with 200 response)
+    - mocked_dns_delegating_carbon_txt_domain
+        (domain only, redirects to other domain wtih DNS TXT record, other domain
+        returns valid TOML with 200 response)
     - mocked_404_carbon_txt_url
-        (No delegation, request for carbon.txt returns 404 status.)
+        (url with path, No delegation, request for carbon.txt returns 404 status.)
+    - mocked_404_carbon_txt_domain
+        (domain only, No delegation, request for carbon.txt returns 404 status.)
 
-Why do we provide these fixtures, instead of just setting up the mocks in the tests themselves? Firstly, because, while it might appear a bit "magic", it makes the tests themselves smaller and easier to follow, and avoids repetition of setup code for common test scenarios. Secondly, and more importantly, however, it allows us to mock HTTP request when running the api tests with pytest-django: the mocks must be set up *before* the test itself, or they won't be available in the live_server that pytest-django provides.
+Why do we provide these fixtures, instead of just setting up the mocks in the tests themselves?
+Firstly, because, while it might appear a bit "magic", it makes the tests themselves smaller and
+easier to follow, and avoids repetition of setup code for common test scenarios. Secondly, and
+more importantly, however, it allows us to mock HTTP request when running the api tests with
+pytest-django: the mocks must be set up *before* the test itself, or they won't be available
+in the live_server that pytest-django provides.
 
 """
 
 import pytest
+import re
 from unittest.mock import MagicMock
 
 
@@ -83,17 +97,16 @@ def mocked_carbon_txt_url(mocked_carbon_txt_domain) -> str:
         )
     ]
 )
-def mocked_http_delegating_carbon_txt_url(minimal_carbon_txt_org, httpx_mock) -> str:
+def mocked_http_delegating_carbon_txt_domain(minimal_carbon_txt_org, httpx_mock) -> str:
     """
-    Return a url which delegates carbon.txt using an HTTP via header,
-    and provide the full URL to the test.
+    Return a domain which delegates carbon.txt using an HTTP via header,
     Ensure the delegated URL responds with a valid carbon.txt and a 200 response.
     """
-    website_url = "https://delegating.withcarbontxt.example.com/carbon.txt"
+    domain = "delegating.withcarbontxt.example.com"
     managed_service_url = "https://delegate.withcarbontxt.example.com/carbon.txt"
     domain_hash_check = "deadb33fdeadf00d"  # TODO: This will need to be generated properly once verification is in place
     httpx_mock.add_response(
-        url=website_url,
+        url=re.compile(f"https?://{domain}"),
         status_code=204,
         content="",
         headers={"Via": f"1.1 {managed_service_url} {domain_hash_check}"},
@@ -105,7 +118,18 @@ def mocked_http_delegating_carbon_txt_url(minimal_carbon_txt_org, httpx_mock) ->
         content=minimal_carbon_txt_org,
         is_reusable=True,
     )
-    return website_url
+    return domain
+
+
+@pytest.fixture
+def mocked_http_delegating_carbon_txt_url(
+    mocked_http_delegating_carbon_txt_domain,
+) -> str:
+    """
+    Return a URL which delegates carbon.txt using an HTTP via header,
+    Ensure the delegated URL responds with a valid carbon.txt and a 200 response.
+    """
+    return f"https://{mocked_http_delegating_carbon_txt_domain}/carbon.txt"
 
 
 @pytest.fixture(
@@ -120,15 +144,14 @@ def mocked_http_delegating_carbon_txt_url(minimal_carbon_txt_org, httpx_mock) ->
         )
     ]
 )
-def mocked_dns_delegating_carbon_txt_url(
+def mocked_dns_delegating_carbon_txt_domain(
     minimal_carbon_txt_org, mocker, httpx_mock
 ) -> str:
     """
-    Return a url which delegates carbon.txt using a DNS TXT record,
-    and provide the full URL to the test.
+    Return a domain which delegates carbon.txt using a DNS TXT record,
     Ensure the delegated URL responds with a valid carbon.txt and a 200 response.
     """
-    website_url = "https://delegating.withcarbontxt.example.com/carbon.txt"
+    domain = "delegating.withcarbontxt.example.com"
     managed_service_url = "https://delegate.withcarbontxt.example.com/carbon.txt"
     domain_hash_check = "deadb33fdeadf00d"  # TODO: This will need to be generated properly once verification is in place
     record = MagicMock()
@@ -136,8 +159,8 @@ def mocked_dns_delegating_carbon_txt_url(
         f'"carbon-txt={managed_service_url} {domain_hash_check}"'
     )
 
-    def dns_lookup_side_effect(domain, record_type):
-        if domain == "delegating.withcarbontxt.example.com":
+    def dns_lookup_side_effect(requested_domain, record_type):
+        if requested_domain == domain:
             return [record]
         else:
             return []
@@ -150,7 +173,18 @@ def mocked_dns_delegating_carbon_txt_url(
         is_reusable=True,
         is_optional=True,
     )
-    return website_url
+    return domain
+
+
+@pytest.fixture
+def mocked_dns_delegating_carbon_txt_url(
+    mocked_dns_delegating_carbon_txt_domain,
+) -> str:
+    """
+    Return a URL which delegates carbon.txt using a DNS TXT record,
+    Ensure the delegated URL responds with a valid carbon.txt and a 200 response.
+    """
+    return f"https://{mocked_dns_delegating_carbon_txt_domain}/carbon.txt"
 
 
 @pytest.fixture(
@@ -165,15 +199,33 @@ def mocked_dns_delegating_carbon_txt_url(
         )
     ]
 )
-def mocked_404_carbon_txt_url(httpx_mock) -> str:
+def mocked_404_carbon_txt_domain(httpx_mock) -> str:
     """
-    Return a 404 error on requests for carbon.txt. Provide the full
-    URL of carbon.txt to the test.
+    Return a 404 error on requests for carbon.txt. Provide the domain
+    name to the test.
     """
-    url = "https://non-existent.withcarbontxt.example.com/carbon.txt"
+    domain = "non-existent.withcarbontxt.example.com"
+    url = f"https://{domain}/carbon.txt"
+    well_known_url = f"https://{domain}/.well-known/carbon.txt"
     httpx_mock.add_response(
         url=url,
         status_code=404,
         is_reusable=True,
+        is_optional=True,
     )
-    return url
+    httpx_mock.add_response(
+        url=well_known_url,
+        status_code=404,
+        is_reusable=True,
+        is_optional=True,
+    )
+    return domain
+
+
+@pytest.fixture
+def mocked_404_carbon_txt_url(mocked_404_carbon_txt_domain) -> str:
+    """
+    Return a 404 error on requests for carbon.txt. Provide the full
+    URL to the test.
+    """
+    return f"https://{mocked_404_carbon_txt_domain}/carbon.txt"

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import httpx
 import pytest
 
-
 from structlog import get_logger
 
 logger = get_logger()
@@ -47,24 +46,25 @@ def test_hitting_validate_url_endpoint_ok(
 
 @pytest.mark.parametrize("url_suffix", ["", "/"])
 def test_hitting_validate_url_endpoint_fail(
-    live_server, url_suffix, mocked_carbon_txt_url
+    live_server, url_suffix, mocked_404_carbon_txt_url
 ):
     api_url = f"{live_server.url}/api/validate/url{url_suffix}"
-    data = {"url": mocked_carbon_txt_url}
+    data = {"url": mocked_404_carbon_txt_url}
     res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
 
     assert res.status_code == 200
 
 
+@pytest.mark.parametrize("url_suffix", ["", "/"])
 def test_hitting_validate_url_endpoint_with_via_delegation(
-    live_server, mocked_http_delegating_carbon_txt_url
+    live_server, url_suffix, mocked_http_delegating_carbon_txt_url
 ):
     """
     When we have a carbon.txt url that is delegating to a another server
     using the http 'via' header, does it follow the delegation and return the
     correct response?
     """
-    api_url = f"{live_server.url}/api/validate/url/"
+    api_url = f"{live_server.url}/api/validate/url{url_suffix}"
     data = {"url": mocked_http_delegating_carbon_txt_url}
     res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
 
@@ -73,24 +73,75 @@ def test_hitting_validate_url_endpoint_with_via_delegation(
     assert actual_provider_domain == "used-in-tests.carbontxt.org"
 
 
+@pytest.mark.parametrize("url_suffix", ["", "/"])
 def test_hitting_validate_url_endpoint_with_txt_delegation(
-    live_server, mocked_dns_delegating_carbon_txt_url
+    live_server, url_suffix, mocked_dns_delegating_carbon_txt_url
 ):
     """
     When we have a carbon.txt url that is delegating to a another server
     using the DNS txt record, does it follow the delegation and return the
     correct response?
     """
-    api_url = f"{live_server.url}/api/validate/url/"
+    api_url = f"{live_server.url}/api/validate/url{url_suffix}"
     data = {"url": mocked_dns_delegating_carbon_txt_url}
     res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
     assert res.status_code == 200
 
-    # https://used-in-tests.carbontxt.org/carbon.txt
 
-    # TODO: Should we serve a different error here, like a 40x?
-    # actual_provider_domain = res.json()["data"]["org"]["disclosures"][0]["domain"]
-    # assert actual_provider_domain == "managed-service.carbontxt.org"
+@pytest.mark.parametrize("url_suffix", ["", "/"])
+def test_hitting_validate_domain_endpoint_ok(
+    live_server, url_suffix, mocked_carbon_txt_domain
+):
+    api_url = f"{live_server.url}/api/validate/domain{url_suffix}"
+    data = {"domain": mocked_carbon_txt_domain}
+    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
+
+    assert res.status_code == 200
+
+
+@pytest.mark.parametrize("url_suffix", ["", "/"])
+def test_hitting_validate_domain_endpoint_fail(
+    live_server, url_suffix, mocked_404_carbon_txt_domain
+):
+    api_url = f"{live_server.url}/api/validate/domain{url_suffix}"
+    data = {"domain": mocked_404_carbon_txt_domain}
+    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
+
+    assert res.status_code == 200
+
+
+@pytest.mark.parametrize("url_suffix", ["", "/"])
+def test_hitting_validate_domain_endpoint_with_via_delegation(
+    live_server, url_suffix, mocked_http_delegating_carbon_txt_domain
+):
+    """
+    When we have a carbon.txt url that is delegating to a another server
+    using the http 'via' header, does it follow the delegation and return the
+    correct response?
+    """
+    api_url = f"{live_server.url}/api/validate/domain{url_suffix}"
+    data = {"domain": mocked_http_delegating_carbon_txt_domain}
+    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
+
+    assert res.status_code == 200
+    print(res.json())
+    actual_provider_domain = res.json()["data"]["org"]["disclosures"][0]["domain"]
+    assert actual_provider_domain == "used-in-tests.carbontxt.org"
+
+
+@pytest.mark.parametrize("url_suffix", ["", "/"])
+def test_hitting_validate_domain_endpoint_with_txt_delegation(
+    live_server, url_suffix, mocked_dns_delegating_carbon_txt_domain
+):
+    """
+    When we have a carbon.txt url that is delegating to a another server
+    using the DNS txt record, does it follow the delegation and return the
+    correct response?
+    """
+    api_url = f"{live_server.url}/api/validate/domain{url_suffix}"
+    data = {"domain": mocked_dns_delegating_carbon_txt_domain}
+    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
+    assert res.status_code == 200
 
 
 # TODO: Do we still need to run this with a full on external server?

--- a/tests/test_validation_logging.py
+++ b/tests/test_validation_logging.py
@@ -133,7 +133,7 @@ class TestLogValidationMiddleware:
 
         # Given a valid request for a url validation
         self.setup(
-            path="/api/validate/file",
+            path="/api/validate/url",
             request={"url": "https://www.example.com/carbon.txt"},
             response={"success": True},
         )
@@ -145,13 +145,47 @@ class TestLogValidationMiddleware:
         # endpoint details, the success status of the validation. the domain and url.
         self.logger.info.assert_called_with(
             "validation_request",
-            endpoint="/api/validate/file",
+            endpoint="/api/validate/url",
             url="https://www.example.com/carbon.txt",
             domain="www.example.com",
             success=True,
         )
         self.db_log_class.assert_called_with(
-            endpoint="/api/validate/file",
+            endpoint="/api/validate/url",
+            url="https://www.example.com/carbon.txt",
+            domain="www.example.com",
+            success=True,
+        )
+        self.db_log_instance.save.assert_called()
+
+    def test_validate_domain_requests_logged_with_domain_and_overriding_url(self):
+        """
+        Domain validation reequests are logged, including the domain requested
+        and the resolved url returned from the validator.
+
+        """
+
+        # Given a valid request for a url validation
+        self.setup(
+            path="/api/validate/domain",
+            request={"domain": "www.example.com"},
+            response={"success": True, "url": "https://www.example.com/carbon.txt"},
+        )
+
+        # When the request is made
+        self.middleware(self.request)
+
+        # A validation request is logged, to the system log and to the database, with the
+        # endpoint details, the success status of the validation. the domain and url.
+        self.logger.info.assert_called_with(
+            "validation_request",
+            endpoint="/api/validate/domain",
+            url="https://www.example.com/carbon.txt",
+            domain="www.example.com",
+            success=True,
+        )
+        self.db_log_class.assert_called_with(
+            endpoint="/api/validate/domain",
             url="https://www.example.com/carbon.txt",
             domain="www.example.com",
             success=True,

--- a/uv.lock
+++ b/uv.lock
@@ -123,6 +123,7 @@ dependencies = [
     { name = "granian" },
     { name = "httpx" },
     { name = "pluggy" },
+    { name = "pydantic-extra-types" },
     { name = "rich" },
     { name = "sentry-sdk", extra = ["django"] },
     { name = "typer" },
@@ -158,6 +159,7 @@ requires-dist = [
     { name = "granian", specifier = ">=1.6.2" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "pluggy", specifier = ">=1.5.0" },
+    { name = "pydantic-extra-types", specifier = ">=2.10.3" },
     { name = "rich", specifier = ">=13.9.2" },
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.18.0" },
     { name = "typer", specifier = ">=0.12.5" },
@@ -1361,6 +1363,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/16/16/b805c74b35607d24d37103007f899abc4880923b04929547ae68d478b7f4/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f", size = 2116814 },
     { url = "https://files.pythonhosted.org/packages/d1/58/5305e723d9fcdf1c5a655e6a4cc2a07128bf644ff4b1d98daf7a9dbf57da/pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769", size = 1738360 },
     { url = "https://files.pythonhosted.org/packages/a5/ae/e14b0ff8b3f48e02394d8acd911376b7b66e164535687ef7dc24ea03072f/pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5", size = 1919411 },
+]
+
+[[package]]
+name = "pydantic-extra-types"
+version = "2.10.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/fa/6b268a47839f8af46ffeb5bb6aee7bded44fbad54e6bf826c11f17aef91a/pydantic_extra_types-2.10.3.tar.gz", hash = "sha256:dcc0a7b90ac9ef1b58876c9b8fdede17fbdde15420de9d571a9fccde2ae175bb", size = 95128 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0a/f6f8e5f79d188e2f3fa9ecfccfa72538b685985dd5c7c2886c67af70e685/pydantic_extra_types-2.10.3-py3-none-any.whl", hash = "sha256:e8b372752b49019cd8249cc192c62a820d8019f5382a8789d0f887338a59c0f3", size = 37175 },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds a new validataion endpoint: `/api/validate/domain`, which
takes a FQDN in the `domain` parameter of the request body and attempts
to find a carbon.txt file for that domain following the standard logic:
checking in the root and .well-known directory for a carbon.txt, and
also checking for delegation via a DNS TXT record and the HTTP Via
header.
    
We also extend the ValidationResults type to optionally include the url
of the found carbon txt, so that this may be returned to the client (and
logged in the validation log middleware, which is itself updated to log
the new endpoint correctly)