### PR TITLE
Fix the read the docs build process

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-      python: latest
+    python: latest
   commands:
     - asdf plugin add uv
     - asdf install uv latest
@@ -16,4 +16,4 @@ build:
 # build the docs with sphinx
 # https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
 sphinx:
-  configuration: docs/conf.py   - uv run sphinx-build docs $READTHEDOCS_OUTPUT/html
+  configuration: docs/conf.py


### PR DESCRIPTION
Read the docs, our free documentation building service updated their system to require slightly different syntax to build docs.

This PR introduces the required change, and removes the part of the line that I don't think we need.