### PR TITLE
Fix read the docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,7 @@ build:
     # RTD needs to build the docs into a specific directory
     # https://docs.readthedocs.io/en/stable/build-customization.html#where-to-put-files
     - mkdir --parents $READTHEDOCS_OUTPUT/html/
+    - sphinx-build docs/ $READTHEDOCS_OUTPUT/html/
 
 # build the docs with sphinx
 # https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-      python: latest
+    python: latest
   commands:
     - asdf plugin add uv
     - asdf install uv latest
@@ -16,4 +16,4 @@ build:
 # build the docs with sphinx
 # https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
 sphinx:
-  configuration: docs/conf.py   - uv run sphinx-build docs $READTHEDOCS_OUTPUT/html
+  configuration: docs/conf.py


### PR DESCRIPTION
This adds the missing invocation of 

```
sphinx-build docs/ $READTHEDOCS_OUTPUT/html/
```

to actually y'know... build the docs.