### PR TITLE
Ca fix read the docs build 2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,7 @@ build:
     # RTD needs to build the docs into a specific directory
     # https://docs.readthedocs.io/en/stable/build-customization.html#where-to-put-files
     - mkdir --parents $READTHEDOCS_OUTPUT/html/
+    - sphinx-build docs/ $READTHEDOCS_OUTPUT/html/
 
 # build the docs with sphinx
 # https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-      python: latest
+    python: latest
   commands:
     - asdf plugin add uv
     - asdf install uv latest
@@ -16,4 +16,4 @@ build:
 # build the docs with sphinx
 # https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
 sphinx:
-  configuration: docs/conf.py   - uv run sphinx-build docs $READTHEDOCS_OUTPUT/html
+  configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
     # RTD needs to build the docs into a specific directory
     # https://docs.readthedocs.io/en/stable/build-customization.html#where-to-put-files
     - mkdir --parents $READTHEDOCS_OUTPUT/html/
-    - sphinx-build docs/ $READTHEDOCS_OUTPUT/html/
+    - uv run sphinx-build docs/ $READTHEDOCS_OUTPUT/html/
 
 # build the docs with sphinx
 # https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/


### PR DESCRIPTION
In order to run `sphinx-build`, we need to wrap it with `uv run`, because otherwise the python path isn't set and the build machine for the docs doesn't know where to find `sphinx-build` the binary we use to generate our project documentation.