### PR TITLE
  Never follow redirection when validating a URL

### DIFF
--- a/src/carbon_txt/web/validation_logging/migrations/0001_initial.py
+++ b/src/carbon_txt/web/validation_logging/migrations/0001_initial.py
@@ -4,22 +4,28 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='ValidationLogEntry',
+            name="ValidationLogEntry",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('timestamp', models.DateTimeField(auto_now_add=True)),
-                ('endpoint', models.CharField(max_length=255)),
-                ('domain', models.CharField(blank=True, max_length=255, null=True)),
-                ('url', models.TextField(blank=True, null=True)),
-                ('success', models.BooleanField(blank=True, null=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("timestamp", models.DateTimeField(auto_now_add=True)),
+                ("endpoint", models.CharField(max_length=255)),
+                ("domain", models.CharField(blank=True, max_length=255, null=True)),
+                ("url", models.TextField(blank=True, null=True)),
+                ("success", models.BooleanField(blank=True, null=True)),
             ],
         ),
     ]

--- a/src/carbon_txt/web/validation_logging/models.py
+++ b/src/carbon_txt/web/validation_logging/models.py
@@ -11,6 +11,8 @@ class ValidationLogEntry(models.Model):
 
     timestamp = models.DateTimeField(auto_now_add=True)
     endpoint = models.CharField(max_length=255)
-    domain = models.CharField(max_length=255, blank=True, null=True)  # Length limit from RFC 1035
+    domain = models.CharField(
+        max_length=255, blank=True, null=True
+    )  # Length limit from RFC 1035
     url = models.TextField(blank=True, null=True)
     success = models.BooleanField(blank=True, null=True)

--- a/tests/http_mocks.py
+++ b/tests/http_mocks.py
@@ -16,7 +16,7 @@ The available mocks are as follows:
         (domain only, valid TOML, 200 response)
     - mocked_http_delegating_carbon_txt_url
         (url with path, delegates to other domain with Via header, other domain
-        returns valid TOML with 200 resposne)
+        returns valid TOML with 200 response)
     - mocked_http_delegating_carbon_txt_domain
         (domain only, delegates to other domain with Via header, other domain
         returns valid TOML with 200 response)
@@ -103,7 +103,7 @@ def mocked_http_delegating_carbon_txt_domain(minimal_carbon_txt_org, httpx_mock)
     Ensure the delegated URL responds with a valid carbon.txt and a 200 response.
     """
     domain = "delegating.withcarbontxt.example.com"
-    managed_service_url = "https://delegate.withcarbontxt.example.com/carbon.txt"
+    managed_service_url = "https://managed-service.withcarbontxt.example.com/carbon.txt"
     domain_hash_check = "deadb33fdeadf00d"  # TODO: This will need to be generated properly once verification is in place
     httpx_mock.add_response(
         url=re.compile(f"https?://{domain}"),
@@ -137,10 +137,10 @@ def mocked_http_delegating_carbon_txt_domain(minimal_carbon_txt_org, httpx_mock)
 def mocked_http_delegating_carbon_txt_url(minimal_carbon_txt_org, httpx_mock) -> str:
     """
     Return a URL which delegates carbon.txt using an HTTP via header,
-    Ensure that the requested URL responds with a valid resposne despite delegation.
+    Ensure that the requested URL responds with a valid response despite delegation.
     """
     domain = "delegating.withcarbontxt.example.com"
-    managed_service_url = "https://delegate.withcarbontxt.example.com/carbon.txt"
+    managed_service_url = "https://managed-service.withcarbontxt.example.com/carbon.txt"
     domain_hash_check = "deadb33fdeadf00d"  # TODO: This will need to be generated properly once verification is in place
     url = f"https://{domain}/carbon.txt"
     httpx_mock.add_response(
@@ -174,7 +174,7 @@ def mocked_dns_delegating_carbon_txt_domain(
     Ensure the delegated URL responds with a valid carbon.txt and a 200 response.
     """
     domain = "delegating.withcarbontxt.example.com"
-    managed_service_url = "https://delegate.withcarbontxt.example.com/carbon.txt"
+    managed_service_url = "https://managed-service.withcarbontxt.example.com/carbon.txt"
     domain_hash_check = "deadb33fdeadf00d"  # TODO: This will need to be generated properly once verification is in place
     record = MagicMock()
     record.to_text.return_value = (
@@ -220,7 +220,7 @@ def mocked_dns_delegating_carbon_txt_url(
     Ensure that the requested URL responds with a valid response despite delegation.
     """
     domain = "delegating.withcarbontxt.example.com"
-    managed_service_url = "https://delegate.withcarbontxt.example.com/carbon.txt"
+    managed_service_url = "https://managed-service.withcarbontxt.example.com/carbon.txt"
     domain_hash_check = "deadb33fdeadf00d"  # TODO: This will need to be generated properly once verification is in place
     url = f"https://{domain}/carbon.txt"
     record = MagicMock()

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -125,8 +125,8 @@ def test_hitting_validate_domain_endpoint_with_via_delegation(
 
     assert res.status_code == 200
     print(res.json())
-    actual_provider_domain = res.json()["data"]["org"]["disclosures"][0]["domain"]
-    assert actual_provider_domain == "used-in-tests.carbontxt.org"
+    actual_url = res.json()["url"]
+    assert actual_url== "https://managed-service.withcarbontxt.example.com/carbon.txt"
 
 
 @pytest.mark.parametrize("url_suffix", ["", "/"])
@@ -141,7 +141,9 @@ def test_hitting_validate_domain_endpoint_with_txt_delegation(
     api_url = f"{live_server.url}/api/validate/domain{url_suffix}"
     data = {"domain": mocked_dns_delegating_carbon_txt_domain}
     res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
+    actual_url = res.json()["url"]
     assert res.status_code == 200
+    assert actual_url== "https://managed-service.withcarbontxt.example.com/carbon.txt"
 
 
 # TODO: Do we still need to run this with a full on external server?

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -36,7 +36,7 @@ class TestFinder:
         result = finder.resolve_domain(mocked_dns_delegating_carbon_txt_domain)
 
         # We get back the URI of the carbon.txt file to lookup
-        assert result == "https://delegate.withcarbontxt.example.com/carbon.txt"
+        assert result == "https://managed-service.withcarbontxt.example.com/carbon.txt"
 
     def test_looking_up_domain_with_delegation_using_http(
         self, mocked_http_delegating_carbon_txt_domain
@@ -54,7 +54,7 @@ class TestFinder:
         result = finder.resolve_domain(mocked_http_delegating_carbon_txt_domain)
 
         # We get back the URI of the carbon.txt file to lookup
-        assert result == "https://delegate.withcarbontxt.example.com/carbon.txt"
+        assert result == "https://managed-service.withcarbontxt.example.com/carbon.txt"
 
     def test_looking_up_uri_simple(self, mocked_carbon_txt_url):
         """Looking up a domain with a carbon.txt file"""

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -20,6 +20,42 @@ class TestFinder:
         # We get back the URI of the carbon.txt file to lookup
         assert result == f"https://{mocked_carbon_txt_domain}/carbon.txt"
 
+    def test_looking_up_domain_with_delegation_using_dns(
+        self, mocked_dns_delegating_carbon_txt_domain
+    ):
+        """
+        Looking up a domain that has a carbon.txt DNS TXT record
+        should delegate us to the correct URL in that TXT record, overriding
+        the original domain
+        """
+        finder = FileFinder()
+
+        # Given a domain
+
+        # When we pass a domain
+        result = finder.resolve_domain(mocked_dns_delegating_carbon_txt_domain)
+
+        # We get back the URI of the carbon.txt file to lookup
+        assert result == "https://delegate.withcarbontxt.example.com/carbon.txt"
+
+    def test_looking_up_domain_with_delegation_using_http(
+        self, mocked_http_delegating_carbon_txt_domain
+    ):
+        """
+        Looking up a domain that has a "via" http header
+        should delegate us to the correct URL in that header, overriding
+        the original domain
+        """
+        finder = FileFinder()
+
+        # Given a domain
+
+        # When we pass a domain
+        result = finder.resolve_domain(mocked_http_delegating_carbon_txt_domain)
+
+        # We get back the URI of the carbon.txt file to lookup
+        assert result == "https://delegate.withcarbontxt.example.com/carbon.txt"
+
     def test_looking_up_uri_simple(self, mocked_carbon_txt_url):
         """Looking up a domain with a carbon.txt file"""
 
@@ -37,20 +73,22 @@ class TestFinder:
         self, mocked_dns_delegating_carbon_txt_url
     ):
         """
-        Looking up a carbon.tx file at a domain that has a carbon.txt DNS TXT record
-        should delegate us to the correct URL in that TXT record, overriding
-        the original URL
+        Looking up a specific carbon.txt file URL at a domain that has a
+        carbon.txt DNS TXT record should NOT delegate us to the domain in
+        the txt record
         """
         finder = FileFinder()
         result = finder.resolve_uri(mocked_dns_delegating_carbon_txt_url)
-        assert result == "https://delegate.withcarbontxt.example.com/carbon.txt"
+        assert result == mocked_dns_delegating_carbon_txt_url
 
     def test_looking_up_uri_with_delegation_using_via(
         self, mocked_http_delegating_carbon_txt_url
     ):
         """
-        Looking up a domain that has a 'via' http header should result
-        in us returning the URL in the via header, not the originaL looked up URL
+         Looking up a specific carbon.txt file URL at a domain that delegates
+         using the HTTP via header shoult NOT delegate us to the domain in
+
+        the via header
         """
 
         finder = FileFinder()
@@ -59,7 +97,7 @@ class TestFinder:
         result = finder.resolve_uri(mocked_http_delegating_carbon_txt_url)
 
         # We get back the URI of the carbon.txt file to lookup
-        assert result == "https://delegate.withcarbontxt.example.com/carbon.txt"
+        assert result == mocked_http_delegating_carbon_txt_url
 
     def test_looking_up_uri_with_no_carbon_txt_at_all(self, mocked_404_carbon_txt_url):
         """

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,22 +4,21 @@ import pathlib
 
 
 class TestCarbonTxtValidator:
-    def test_validate_file_with_greenweb_root(self):
+    def test_validate_domain_without_carbon_txt(self, mocked_404_carbon_txt_domain):
         """
-        This should show a failure, as thegreenwebfoundation.org does not currently have a carbon.txt file,
-        but does serve content at the root path (i.e. '/')
+        This should show a failure, as there is no carbon.txt file at this domain
         """
         validator = validators.CarbonTxtValidator()
-        res = validator.validate_url("https://www.thegreenwebfoundation.org")
+        res = validator.validate_domain(f"https://{mocked_404_carbon_txt_domain}")
         assert not res.result
         assert res.exceptions
 
-    def test_validate_file_with_greenweb_carbon_txt(self):
+    def test_validate_url_without_carbon_txt(self, mocked_404_carbon_txt_url):
         """
-        This should show a failure, as thegreenwebfoundation.org does not currently have a carbon.txt file
+        This should show a failure, as there is no carbon.txt file at this URL
         """
         validator = validators.CarbonTxtValidator()
-        res = validator.validate_url("https://www.thegreenwebfoundation.org/carbon.txt")
+        res = validator.validate_url(mocked_404_carbon_txt_url)
         assert not res.result
         assert res.exceptions
 


### PR DESCRIPTION
When a request for a specific, full carbon.txt file url is requested, we
should not folllow DNS and HTTP delegation logic, and always validate
the specific file requested.

This comes from a discussion with Chris earlier today, in the context of
problems experienced by go.eco (and others) in validating carbon.txt
files hosted behind cloudflare, which adds a Via header which _doesn't_
comform to the standard we expect, and therefore causes an error on
validation.

This causes problems, as their carbon.txt shows as invalid when it
actually is not, for non-obvious reasons which aren't easily addressed
by the user themselves. Instead, much better to show them that their
carbon.txt is in fact valid, while we go about fixing the root cause of
the problem themselves.

It also makes more sense now we have a "validate domain" endpoint which
can handle the logic for delegation and discovery of carbon txts.
