### PR TITLE
Version bump to v0.0.14, Update of changelog since v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,58 @@ Fixed, Changed, Added, Removed, Fixed, Security
 
 ## Unreleased
 
+## [0.0.14]
 
+
+### Added
+
+- Logging of validation requests in the API to database and stdout
+- API endpoint for validation of domains
+- Sample output for issue 8 raised by Andy
+- Extra documentation for creating external plugin
 
 ### Changed
 
+- Never follow redirection when validating a URL
+- Update our plugin listings, and remove duplicate tutorial
+- Update docs, linking to new site
+- Tidy up docs on the GreenwebCSRD processor
+- Replace Credentials with Disclosures
+
+### Fixed
+
+- Fix readthedocs build script
+  Use http and dns mocks in test suite
+
+## [0.0.13]
+
+### Changed
+
+- Refactor the CSRD Processor for easier plugins
+- Tidy up logging so it's in one file
+
+## [0.0.12]
+
+### Added
+
+- Add new defaults for seeing logger output
+- Add safer loading of plugins
+- Add a guidance and screenshots for using Bruno for GUI API tests
+- Add example Bruno tests
+- Add the ESRS excel file with our data name mappings
+- Add first pass at docs on using bundled plugins
+- Add first class and test for parsing CSRD files
+- Add exploration of fetching values from online CSRD report
+- Add missing Apache license
+
+### Changed
+
+- Update docs to flesh out usage instructions
 - Update pre-commit hooks to 0.5.0 and Ruff to 0.8.0
+- Update tests and code for name change
+- Rework the docs for people using validator
+- Update API to return sanitized error notifications
+- Update marimo demo to for choosing different datapoints
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carbon-txt"
-version = "0.0.13"
+version = "0.0.14"
 description = "A command line tool containing a validator for carbon.txt files, by the Green Web Foundation"
 authors = [
     { name = "Chris Adams" },


### PR DESCRIPTION
Bit of a formality, but for visibility:

I have bumped the version to v0.0.14, and also backfilled the changelog (from commit history), which had nothing since v0.0.11.

