### PR TITLE
New delegation mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Fixed, Changed, Added, Removed, Fixed, Security
 
 ## Unreleased
 
+ - Use of 'Via' HTTP header and `carbon-txt` DNS TXT record deprecated in favour of new `Carbon-Txt-Location` HTTP header and `carbon-txt-location` DNS TXT record.
+ - Formalise the order of priority in carbon.txt domain lookups: Local file in root, followed by local file in `.well-known`, followed by DNS TXT record, followed by HTTP Header.
+ - Ensure that checks for a specific carbon.txt URL do not follow the domain delegation lookup logic
+
 ## [0.0.14]
 
 
@@ -31,7 +35,7 @@ Fixed, Changed, Added, Removed, Fixed, Security
 ### Fixed
 
 - Fix readthedocs build script
-  Use http and dns mocks in test suite
+  Use HTTP and DNS mocks in test suite
 
 ## [0.0.13]
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -150,6 +150,6 @@ As you make changes to the documentation source files, the rendered results will
 
 ### Updating the public documentation
 
-Every time changes are merged into the `main` branch, a build script at [Read the docs](https://about.readthedocs.com/?ref=readthedocs.org) generates the documentation to serve at the url below:
+Every time changes are merged into the `main` branch, a build script at [Read the docs](https://about.readthedocs.com/?ref=readthedocs.org) generates the documentation to serve at the URL below:
 
 [https://carbon-txt-validator.readthedocs.io](https://carbon-txt-validator.readthedocs.io)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -147,6 +147,6 @@ To see default values that can be override, see the `base.py` file, in `src/web/
 
 #### Monitoring and gathering stats on use of the API.
 
-When run as a server, the carbon.txt validator logs anonymous usage data about validation requests received, in order to track the uptake of the carbon.xt standard. We log the validation endpoint used (`file`, `url`, or `domain`), the domain requested and carbon.txt url (in the case of requests to the `url` and `domain` endpoints), and whether or not the validation was succesful.
+When run as a server, the carbon.txt validator logs anonymous usage data about validation requests received, in order to track the uptake of the carbon.txt standard. We log the validation endpoint used (`file`, `url`, or `domain`), the domain requested and carbon.txt URL (in the case of requests to the `url` and `domain` endpoints), and whether or not the validation was succesful.
 
 This information is saved to the application database (configured with the `DATABASE_URL` environment variable, as described above) in the table `validation_logging_ValidationLogEntry`. It is also output as an INFO message to the log, with a log name of `carbon_txt.web.validation_logging.middleware`.

--- a/docs/using_plugins.md
+++ b/docs/using_plugins.md
@@ -69,7 +69,7 @@ Should return output, that (once formatted) similar to the JSON below:
     "Attempting to validate url: https://used-in-tests.carbontxt.org/carbon-txt-with-csrd-and-renewables.txt",
     "Trying a DNS delegated lookup for URI: used-in-tests.carbontxt.org",
     "None found. Continuing.",
-    "Checking for a 'via' header in the response: https://used-in-tests.carbontxt.org/carbon-txt-with-csrd-and-renewables.txt",
+    "Checking for a 'CarbonTxt-Location' header in the response: https://used-in-tests.carbontxt.org/carbon-txt-with-csrd-and-renewables.txt",
     "None found. Continuing.",
     "Carbon.txt file parsed as valid TOML.",
     "Parsed TOML was recognised as valid Carbon.txt file.\n"
@@ -153,7 +153,7 @@ Our request now returns extra output in the `document_data` part of the object. 
     "Attempting to validate url: https://used-in-tests.carbontxt.org/carbon-txt-with-csrd-and-renewables.txt",
     "Trying a DNS delegated lookup for URI: used-in-tests.carbontxt.org",
     "None found. Continuing.",
-    "Checking for a 'via' header in the response: https://used-in-tests.carbontxt.org/carbon-txt-with-csrd-and-renewables.txt",
+    "Checking for a 'CarbonTxt-Location' header in the response: https://used-in-tests.carbontxt.org/carbon-txt-with-csrd-and-renewables.txt",
     "None found. Continuing.",
     "Carbon.txt file parsed as valid TOML.",
     "Parsed TOML was recognised as valid Carbon.txt file.\n",

--- a/src/carbon_txt/processors.py
+++ b/src/carbon_txt/processors.py
@@ -27,7 +27,7 @@ class DataPoint(BaseModel):
     value: str | float | int
     unit: str  # the type of unit the value is expressed in
     context: str  # the line in the original xml file this value is from
-    file: str  # the url to the file this value is from
+    file: str  # the URL to the file this value is from
     start_date: datetime.date
     end_date: datetime.date
 
@@ -225,7 +225,7 @@ class GreenwebCSRDProcessor:
         """
         Set up the GreenwebCSRDProcessor with an instance of ArelleProcessor.
         Used when the GreenwebCSRDProcessor is initialized wihtout a ArellProcessor instance
-        or report url passed in.
+        or report URL passed in.
         """
         self.arelle_processor = arelle_processor
 

--- a/src/carbon_txt/validators.py
+++ b/src/carbon_txt/validators.py
@@ -255,7 +255,7 @@ class CarbonTxtValidator:
             )
 
         # the file path is reachable, and but it's not valid TOML. We re-raise the exception
-        # with the url listed in the error message, so it's clear to what URL the error refers to
+        # with the URL listed in the error message, so it's clear to what URL the error refers to
         except exceptions.NotParseableTOML as ex:
             message = f"A file was found at {url}: but it wasn't parseable TOML. Error was: {ex}"
             log_exception_safely(ex, message, errors, self.event_log)

--- a/src/carbon_txt/web/api.py
+++ b/src/carbon_txt/web/api.py
@@ -137,7 +137,7 @@ def validate_url(
 
     Args:
         request: The request object.
-        carbon_txt_url_data: The request body containing the url of the carbon.txt file.
+        carbon_txt_url_data: The request body containing the URL of the carbon.txt file.
 
     Returns:
         dict: A dictionary containing the success status and either the validated data or errors.

--- a/tests/test_api_external.py
+++ b/tests/test_api_external.py
@@ -56,12 +56,12 @@ def test_hitting_validate_url_endpoint_fail(
 
 
 @pytest.mark.parametrize("url_suffix", ["", "/"])
-def test_hitting_validate_url_endpoint_with_via_delegation(
+def test_hitting_validate_url_endpoint_with_http_header_delegation(
     live_server, url_suffix, mocked_http_delegating_carbon_txt_url
 ):
     """
-    When we have a carbon.txt url that is delegating to a another server
-    using the http 'via' header, does it follow the delegation and return the
+    When we have a carbon.txt URL that is delegating to a another server
+    using the HTTP 'CarbonTxt-Location' header, does it follow the delegation and return the
     correct response?
     """
     api_url = f"{live_server.url}/api/validate/url{url_suffix}"
@@ -78,8 +78,8 @@ def test_hitting_validate_url_endpoint_with_txt_delegation(
     live_server, url_suffix, mocked_dns_delegating_carbon_txt_url
 ):
     """
-    When we have a carbon.txt url that is delegating to a another server
-    using the DNS txt record, does it follow the delegation and return the
+    When we have a carbon.txt URL that is delegating to a another server
+    using the DNS TXT record, does it follow the delegation and return the
     correct response?
     """
     api_url = f"{live_server.url}/api/validate/url{url_suffix}"
@@ -111,12 +111,12 @@ def test_hitting_validate_domain_endpoint_fail(
 
 
 @pytest.mark.parametrize("url_suffix", ["", "/"])
-def test_hitting_validate_domain_endpoint_with_via_delegation(
+def test_hitting_validate_domain_endpoint_with_http_header_delegation(
     live_server, url_suffix, mocked_http_delegating_carbon_txt_domain
 ):
     """
-    When we have a carbon.txt url that is delegating to a another server
-    using the http 'via' header, does it follow the delegation and return the
+    When we have a carbon.txt URL that is delegating to a another server
+    using the HTTP 'CarbonTxt-Location' header, does it follow the delegation and return the
     correct response?
     """
     api_url = f"{live_server.url}/api/validate/domain{url_suffix}"
@@ -126,7 +126,7 @@ def test_hitting_validate_domain_endpoint_with_via_delegation(
     assert res.status_code == 200
     print(res.json())
     actual_url = res.json()["url"]
-    assert actual_url== "https://managed-service.withcarbontxt.example.com/carbon.txt"
+    assert actual_url == "https://managed-service.withcarbontxt.example.com/carbon.txt"
 
 
 @pytest.mark.parametrize("url_suffix", ["", "/"])
@@ -134,8 +134,8 @@ def test_hitting_validate_domain_endpoint_with_txt_delegation(
     live_server, url_suffix, mocked_dns_delegating_carbon_txt_domain
 ):
     """
-    When we have a carbon.txt url that is delegating to a another server
-    using the DNS txt record, does it follow the delegation and return the
+    When we have a carbon.txt URL that is delegating to a another server
+    using the DNS TXT record, does it follow the delegation and return the
     correct response?
     """
     api_url = f"{live_server.url}/api/validate/domain{url_suffix}"
@@ -143,7 +143,7 @@ def test_hitting_validate_domain_endpoint_with_txt_delegation(
     res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
     actual_url = res.json()["url"]
     assert res.status_code == 200
-    assert actual_url== "https://managed-service.withcarbontxt.example.com/carbon.txt"
+    assert actual_url == "https://managed-service.withcarbontxt.example.com/carbon.txt"
 
 
 # TODO: Do we still need to run this with a full on external server?

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -25,8 +25,7 @@ class TestFinder:
     ):
         """
         Looking up a domain that has a carbon.txt DNS TXT record
-        should delegate us to the correct URL in that TXT record, overriding
-        the original domain
+        should delegate us to the correct URL in that TXT record,
         """
         finder = FileFinder()
 
@@ -42,9 +41,8 @@ class TestFinder:
         self, mocked_http_delegating_carbon_txt_domain
     ):
         """
-        Looking up a domain that has a "via" http header
-        should delegate us to the correct URL in that header, overriding
-        the original domain
+        Looking up a domain that has a "CarbonTxt-Location" HTTP header
+        should delegate us to the correct URL in that header,
         """
         finder = FileFinder()
 
@@ -78,17 +76,16 @@ class TestFinder:
         the txt record
         """
         finder = FileFinder()
-        result = finder.resolve_uri(mocked_dns_delegating_carbon_txt_url)
-        assert result == mocked_dns_delegating_carbon_txt_url
+        with pytest.raises(UnreachableCarbonTxtFile):
+            finder.resolve_uri(mocked_dns_delegating_carbon_txt_url)
 
-    def test_looking_up_uri_with_delegation_using_via(
+    def test_looking_up_uri_with_delegation_using_http_headder(
         self, mocked_http_delegating_carbon_txt_url
     ):
         """
          Looking up a specific carbon.txt file URL at a domain that delegates
-         using the HTTP via header shoult NOT delegate us to the domain in
-
-        the via header
+         using the HTTP CarbonTxt-Location header shoult NOT delegate us to the domain in
+        the header
         """
 
         finder = FileFinder()
@@ -101,14 +98,11 @@ class TestFinder:
 
     def test_looking_up_uri_with_no_carbon_txt_at_all(self, mocked_404_carbon_txt_url):
         """
-        Looking up a domain that has no carbon.txt file should still return
-        the uri to check.
+        Looking up a domain that has no carbon.txt file should raise an exception
         """
         finder = FileFinder()
-
-        assert (
-            finder.resolve_uri(mocked_404_carbon_txt_url) == mocked_404_carbon_txt_url
-        )
+        with pytest.raises(UnreachableCarbonTxtFile):
+            finder.resolve_uri(mocked_404_carbon_txt_url)
 
     def test_fetch_carbon_txt_file(self, mocked_carbon_txt_url):
         finder = FileFinder()
@@ -127,3 +121,70 @@ class TestFinder:
 
         with pytest.raises(UnreachableCarbonTxtFile):
             finder.fetch_carbon_txt_file(mocked_404_carbon_txt_url)
+
+    def test_file_takes_precedence_over_dns(
+        self, mocked_carbon_txt_domain_with_file_and_dns_delegation
+    ):
+        """
+        When a domain has a carbon.txt file in the root directory, and also a DNS delegation record,
+        the carbon.txt file should take precedence.
+        """
+        finder = FileFinder()
+
+        # Given a domain with both a DNS delegation record and a carbon.txt
+
+        # When we pass a domain
+        result = finder.resolve_domain(
+            mocked_carbon_txt_domain_with_file_and_dns_delegation
+        )
+
+        # We get back the URI of the carbon.txt file at the domain itself
+        assert (
+            result
+            == f"https://{mocked_carbon_txt_domain_with_file_and_dns_delegation}/carbon.txt"
+        )
+
+    def test_dns_takes_precedence_over_http_header(
+        self, mocked_carbon_txt_domain_with_dns_and_http_delegation
+    ):
+        """
+        When a domain has both a DNS delegation record, and an HTTP delegation header
+        the URL in the DNS record should take precedence.
+        """
+        finder = FileFinder()
+
+        # Given a domain with both a DNS delegation record and an HTTP delegation header
+
+        # When we pass a domain
+        result = finder.resolve_domain(
+            mocked_carbon_txt_domain_with_dns_and_http_delegation
+        )
+
+        # We get back the URI of the carbon.txt file at managed service referred to by the
+        # DNS record
+        assert (
+            result == "https://dns-managed-service.withcarbontxt.example.com/carbon.txt"
+        )
+
+    def test_recursive_delegation(
+        self, mocked_carbon_txt_domain_with_recursive_delegation
+    ):
+        """
+        When a domain delegates to another domain, rather than a full carbon.txt url,
+        the delegation following process should be applied recursively until a full
+        carbon.txt URL is found.
+        """
+        finder = FileFinder()
+
+        # Given a domain which delegates carbon.txt to a first manaaged service, which in
+        # turn delegates to a second managed service
+
+        # When we pass a domain
+        result = finder.resolve_domain(
+            mocked_carbon_txt_domain_with_recursive_delegation
+        )
+
+        # We get back the URI of the carbon.txt file at the second managed service
+        assert (
+            result == "https://second-managed-service.withcarbontxt.example.com/carbon.txt"
+        )

--- a/tests/test_validation_logging.py
+++ b/tests/test_validation_logging.py
@@ -102,7 +102,7 @@ class TestLogValidationMiddleware:
 
     def test_validate_file_requests_logged_without_url_or_domain(self):
         """
-        File validation requests are logged, without any url or domain metadata.
+        File validation requests are logged, without any URL or domain metadata.
         """
 
         # Given a valid request for a file validation
@@ -127,11 +127,11 @@ class TestLogValidationMiddleware:
 
     def test_validate_url_requests_logged_with_url_and_domain(self):
         """
-        URL validation reequests are logged, including the url and domain metadata
+        URL validation reequests are logged, including the URL and domain metadata
 
         """
 
-        # Given a valid request for a url validation
+        # Given a valid request for a URL validation
         self.setup(
             path="/api/validate/url",
             request={"url": "https://www.example.com/carbon.txt"},
@@ -161,11 +161,11 @@ class TestLogValidationMiddleware:
     def test_validate_domain_requests_logged_with_domain_and_overriding_url(self):
         """
         Domain validation reequests are logged, including the domain requested
-        and the resolved url returned from the validator.
+        and the resolved URL returned from the validator.
 
         """
 
-        # Given a valid request for a url validation
+        # Given a valid request for a URL validation
         self.setup(
             path="/api/validate/domain",
             request={"domain": "www.example.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -110,7 +110,7 @@ wheels = [
 
 [[package]]
 name = "carbon-txt"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "arelle-release" },


### PR DESCRIPTION
This PR updates the delegation logic to follow the new mechanism
outlined in ADR02, as well as adding tests that carbon.txt locations are
checked in the correct order, and that recursive delegation works as
specified. We also refactor the finder to make the order of lookups more
explicit.