### PR TITLE
Add github action for automatic deploying when we push to `prod`

### DIFF
--- a/.github/workflows/run-deploy.yml
+++ b/.github/workflows/run-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run playbook
         uses: dawidd6/action-ansible-playbook@v2
         with:
-          playbook: ./ansible/deploy.yml
+          playbook: ./ansible/playbooks/deploy.yml
           directory: ./
           key: ${{secrets.SSH_PRIVATE_KEY}}
           inventory: |

--- a/.github/workflows/run-deploy.yml
+++ b/.github/workflows/run-deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy latest version of API service to production
+
+on:
+  push:
+    branches:
+      - prod
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./
+
+jobs:
+  deploy:
+    environment: prod
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use turnstyle to serialise deploys
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run playbook
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: ./ansible/deploy.yml
+          directory: ./
+          key: ${{secrets.SSH_PRIVATE_KEY}}
+          inventory: |
+          options: |
+            --inventory ./ansible/inventories/prod.yml
+        env:
+          ANSIBLE_STDOUT_CALLBACK: yaml
+          PYTHONDONTWRITEBYTECODE: 1
+          CARBON_TXT_API_DATABASE_URL: ${{ secrets.CARBON_TXT_API_DATABASE_URL }}
+          CARBON_TXT_API_SECRET_KEY: ${{ secrets.CARBON_TXT_API_SECRET_KEY }}
+          CARBON_TXT_API_DJANGO_SETTINGS_MODULE: ${{ secrets.CARBON_TXT_API_DJANGO_SETTINGS_MODULE }}
+          CARBON_TXT_API_SENTRY_DSN: ${{ secrets.CARBON_TXT_API_SENTRY_DSN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of the latest version of the API service to the production environment. The workflow is triggered on pushes to the `prod` branch and ensures serialized deployments using the `turnstyle` action.

### New deployment workflow:

* [`.github/workflows/run-deploy.yml`](diffhunk://#diff-caba8d11eda0db195244705306667f508e47a95c5b91730b2356e242758a4269R1-R43): Added a GitHub Actions workflow to deploy the API service to production. It includes steps for code checkout, serialized deployment using `turnstyle`, and running an Ansible playbook with required secrets and environment variables.