### PR TITLE
version bump: v0.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Fixed, Changed, Added, Removed, Fixed, Security
 
 ## Unreleased
 
+## [0.0.16]
+
+###  Added
+ - Expose delegation method on domain endpoint.
+ - Add distinguish between failing 200 and 404 responses
+ - Add handling HTML served at example.org/carbon.txt
+
+### Changed
+ - Ensure DNS record delegation takes priority
+
+### Fixed
+ - add pyright config to get rid of spurious typecheck warnings
+ - Stop the CI double runs
+ - Add github action for deploying the service
+
+
 ## [0.0.15]
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carbon-txt"
-version = "0.0.15"
+version = "0.0.16"
 description = "A command line tool containing a validator for carbon.txt files, by the Green Web Foundation"
 authors = [
     { name = "Chris Adams" },


### PR DESCRIPTION
Version bump! This is all old stuff that we never did a release for (as we mostly needed it in the live site rather than the library, until now. We should watch that in future and try and release more frequently!

cc @mrchrisadams for your information, but will merge and deploy directly as it's not really at all controversial.