### PR TITLE
Add an overrideable, descriptive User-Agent to all Finder http requests

### DIFF
--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -1,5 +1,5 @@
 import pytest
-
+import re
 from carbon_txt.finders import FileFinder  # type: ignore
 from carbon_txt.exceptions import UnreachableCarbonTxtFile  # type: ignore
 
@@ -236,3 +236,38 @@ class TestFinder:
         # Then the http transport library should be called with the timeout.
         for request in httpx_mock.get_requests():
             assert set(request.extensions["timeout"].values()) == set([timeout])
+
+    def test_passing_user_agent_to_finder(self, mocked_carbon_txt_domain, httpx_mock):
+        """
+        Passing a user agent to the finder constructor passes it
+        through to any httpx requests made
+        """
+
+        # Given a FileFinder with a UserAgent
+        user_agent = "MyCarbonTxtApp/1.0"
+        finder = FileFinder(http_user_agent=user_agent)
+
+        # When we pass a domain
+        finder.resolve_domain(mocked_carbon_txt_domain)
+
+        # Then the http transport library should be called with the timeout.
+        for request in httpx_mock.get_requests():
+            assert request.headers["User-Agent"] == user_agent
+
+    def test_default_user_agent(self, mocked_carbon_txt_domain, httpx_mock):
+        """
+        The User agent defaults to a descriptive string with the version number and a URL.
+        """
+
+        # Given a FileFinder with a UserAgent
+        user_agent_re = re.compile(
+            "CarbonTxtValidator/[0-9]+\\.[0-9]+\\.[0-9]+ \\(https://carbontxt.org/tools/validator\\)"
+        )
+        finder = FileFinder()
+
+        # When we pass a domain
+        finder.resolve_domain(mocked_carbon_txt_domain)
+
+        # Then the http transport library should be called with the timeout.
+        for request in httpx_mock.get_requests():
+            assert re.match(user_agent_re, request.headers["User-Agent"])


### PR DESCRIPTION
This will be overriden in the admin-portal with a link to a page to provide information on what the greenweb checker is doing, and our caching strategy, etc.