### PR TITLE
[wip] Improve CSRD processor performance: 

### DIFF
--- a/src/carbon_txt/process_csrd_document.py
+++ b/src/carbon_txt/process_csrd_document.py
@@ -1,4 +1,8 @@
+import os
+from urllib.parse import urlparse
+
 from .hookspecs import hookimpl
+from .http_client import HTTPClient
 from .schemas.common import Disclosure
 from .processors import GreenwebCSRDProcessor
 import logging
@@ -8,6 +12,12 @@ from typing import Optional
 from structlog import get_logger
 
 logger = get_logger()
+
+# File extensions that could plausibly be ESEF iXBRL documents
+ESEF_VALID_EXTENSIONS = {".xhtml", ".xbrl", ".xml", ".zip", ".htm", ".html"}
+
+# Content types that could plausibly be ESEF iXBRL documents
+ESEF_VALID_CONTENT_TYPES = {"xhtml", "html", "xml", "application/zip", "application/octet-stream"}
 
 
 def log_safely(log_message: str, logs: Optional[list], level=logging.INFO):
@@ -19,6 +29,72 @@ def log_safely(log_message: str, logs: Optional[list], level=logging.INFO):
         logs.append(log_message)
 
 
+def _looks_like_esef_url(url: str) -> bool:
+    """
+    Quick heuristic: does the URL path suggest it could be an ESEF document?
+
+    This is a zero-cost check that prevents obviously wrong URLs (e.g. PDFs,
+    images, CSVs) from being passed to Arelle, which would waste several
+    seconds on initialisation before failing.
+
+    Extensionless URLs are allowed through (they might be served with
+    correct content types).
+    """
+    parsed = urlparse(url)
+    ext = os.path.splitext(parsed.path)[1].lower()
+    # Allow extensionless URLs and local files without extensions
+    return ext in ESEF_VALID_EXTENSIONS or ext == ""
+
+
+def _quick_validate_remote_csrd_url(
+    url: str, http_client: Optional[HTTPClient] = None, logs: Optional[list] = None
+) -> bool:
+    """
+    Lightweight HTTP HEAD check before invoking Arelle.
+
+    Catches unreachable URLs, 404s, and obviously non-XBRL content types
+    in ~100-200ms, avoiding the 2+ second cost of Arelle session startup
+    for URLs that will certainly fail.
+
+    Only checks remote (http/https) URLs. Local file paths are always
+    allowed through.
+    """
+    if not url.startswith(("http://", "https://")):
+        return True  # local files - let Arelle handle them
+
+    if http_client is None:
+        http_client = HTTPClient()
+
+    try:
+        response = http_client.head(url, follow_redirects=True)
+        if response.status_code >= 400:
+            log_safely(
+                f"CSRD pre-check: URL {url} returned HTTP {response.status_code}",
+                logs,
+                level=logging.WARNING,
+            )
+            return False
+
+        content_type = response.headers.get("content-type", "").lower()
+        if content_type and not any(ct in content_type for ct in ESEF_VALID_CONTENT_TYPES):
+            log_safely(
+                f"CSRD pre-check: URL {url} has content-type '{content_type}' "
+                f"which doesn't look like an ESEF document",
+                logs,
+                level=logging.WARNING,
+            )
+            return False
+
+        return True
+    except Exception as e:
+        log_safely(
+            f"CSRD pre-check: could not reach {url}: {e}",
+            logs,
+            level=logging.WARNING,
+        )
+        return False
+
+
 plugin_name = "csrd_greenweb"
 
 
@@ -26,6 +102,7 @@ plugin_name = "csrd_greenweb"
 def process_document(
     document: Disclosure,
     logs: Optional[list],
+    http_client: Optional[HTTPClient] = None,
 ):
     """
     Listen for documents linked in the carbon.txt file that are iXBRL CSRD reports,
@@ -41,6 +118,25 @@ def process_document(
             f"{__name__}: CSRD Report found. Processing report with Arelle: {document}",
             logs=logs,
         )
+
+        # Quick extension check - zero cost, catches obviously wrong file types
+        if not _looks_like_esef_url(document.url):
+            log_safely(
+                f"CSRD pre-check: URL {document.url} does not have an ESEF-compatible "
+                f"file extension. Skipping Arelle processing.",
+                logs=logs,
+            )
+            return {"logs": logs}
+
+        # Lightweight HTTP pre-validation for remote URLs - avoids ~2s Arelle
+        # startup cost for unreachable/wrong URLs
+        if not _quick_validate_remote_csrd_url(document.url, http_client, logs):
+            log_safely(
+                f"CSRD pre-check: URL {document.url} failed pre-validation. "
+                f"Skipping Arelle processing.",
+                logs=logs,
+            )
+            return {"logs": logs}
 
         try:
             processor = GreenwebCSRDProcessor(report_url=document.url)

--- a/src/carbon_txt/processors/csrd_document.py
+++ b/src/carbon_txt/processors/csrd_document.py
@@ -1,4 +1,6 @@
 import datetime
+from collections import defaultdict
+
 from arelle import (  # type: ignore
     ModelXbrl,
 )
@@ -32,6 +34,86 @@ class DataPoint(BaseModel):
     end_date: datetime.date
 
 
+class ArelleSessionManager:
+    """
+    Manages a reusable Arelle Session to avoid the overhead of creating
+    a new controller, plugin manager, and logging infrastructure for
+    every report loaded.
+
+    Uses skipDTS=True to skip full taxonomy discovery, which cuts load
+    time by ~85%. Since we only need to read fact values by local name,
+    we build our own index from the parsed facts instead of relying on
+    Arelle's factsByLocalName (which requires full DTS).
+    """
+
+    def __init__(self) -> None:
+        self._session: Session | None = None
+
+    def load_report(self, report_url: str) -> ModelXbrl.ModelXbrl:
+        """
+        Load an XBRL/iXBRL report and return the parsed model.
+
+        Reuses the underlying Arelle Session across calls, avoiding
+        repeated controller and plugin manager initialisation.
+
+        Args:
+            report_url: Path or URL to the report file.
+
+        Returns:
+            The parsed ModelXbrl for the report.
+
+        Raises:
+            NoLoadableCSRDFile: If Arelle cannot load the file.
+        """
+        if self._session is None:
+            self._session = Session()
+
+        options = RuntimeOptions(
+            entrypointFile=str(report_url),
+            logLevel="ERROR",
+            logFile="logToBuffer",
+            keepOpen=True,
+            # Skip full Discoverable Taxonomy Set loading. We only need
+            # to read fact values by local name, so the full taxonomy
+            # schema/linkbase traversal is unnecessary. This reduces
+            # load time from ~2s to ~0.3s per report.
+            skipDTS=True,
+        )
+
+        self._session.run(options)
+        models = self._session.get_models()
+
+        # get_models() returns all models loaded across runs with keepOpen=True,
+        # so the latest model is always the last one
+        model = models[-1]
+
+        if "FileNotLoadable" in model.errors:
+            raise NoLoadableCSRDFile(
+                f"Could not load the file at {report_url} as a CSRD report"
+            )
+
+        return model
+
+    def close(self) -> None:
+        """Close the Arelle session and release resources."""
+        if self._session is not None:
+            self._session.close()
+            self._session = None
+
+
+# Module-level shared session manager. Reused across ArelleProcessor
+# instances to avoid repeated Arelle controller startup.
+_shared_session_manager: ArelleSessionManager | None = None
+
+
+def get_shared_session_manager() -> ArelleSessionManager:
+    """Get or create the shared ArelleSessionManager singleton."""
+    global _shared_session_manager
+    if _shared_session_manager is None:
+        _shared_session_manager = ArelleSessionManager()
+    return _shared_session_manager
+
+
 class ArelleProcessor:
     """
     A processor for reading and parsing CSRD report documents.
@@ -42,58 +124,58 @@ class ArelleProcessor:
     It can be used directly to parse a report, and service queries for specific datapoints,
     but it's designed to be wrapped by other objects that might consume its simplified API as plugins.
 
-    See the GreenwebCSRDProcessor as an exmaple of a class consumign this object's API in a CSRD plugin.
+    See the GreenwebCSRDProcessor as an example of a class consuming this object's API in a CSRD plugin.
     """
 
     report_url: str
-    xbrls: list[ModelXbrl.ModelXbrl]
+    _model: ModelXbrl.ModelXbrl
+    _facts_by_local_name: dict[str, set]
 
-    def __init__(self, report_url: str) -> None:
+    def __init__(
+        self,
+        report_url: str,
+        session_manager: ArelleSessionManager | None = None,
+    ) -> None:
         """
         Initialize the Arelle Processor loading the report from the given URL.
 
-        This begin a session with Arelle, providing an object that will accept
-        other objects querying the parsed report for data.
+        Uses a shared ArelleSessionManager by default to reuse the Arelle
+        session across multiple report loads, avoiding repeated controller
+        and plugin manager initialisation.
 
         Args:
-            report_url (str): The URL of the report to process
-
+            report_url: The URL or path of the report to process.
+            session_manager: Optional ArelleSessionManager to use. If None,
+                uses the shared module-level singleton.
         """
-
         self.report_url = report_url
 
-        options = RuntimeOptions(
-            entrypointFile=str(report_url),
-            # TODO it's not clear how to get the output from the logger to only log to
-            # the handler. We ideally want to ONLY log to the handler, but there always seems to be
-            # output logged to stdout, even if we pass in a null handler.
-            # the only option we seem to have is to set the log level
-            logLevel="ERROR",
-            logFile="logToBuffer",
-            # we need to keep the file open to fetch data from the xml
-            # file later, when we call various method on the object
-            # TODO: does file close when this object is garbage collected?
-            keepOpen=True,
-        )
+        if session_manager is None:
+            session_manager = get_shared_session_manager()
 
-        with Session() as session:
-            session.run(options)
-            self.xbrls = session.get_models()
-            if "FileNotLoadable" in self.xbrls[0].errors:
-                raise NoLoadableCSRDFile(
-                    f"Could not load the file at {self.report_url} as a CSRD report"
-                )
-            session.close()
+        self._model = session_manager.load_report(report_url)
+
+        # Build our own local name index from the parsed facts.
+        # With skipDTS=True, Arelle's built-in factsByLocalName is not
+        # populated, so we construct an equivalent index here.
+        self._facts_by_local_name = defaultdict(set)
+        for fact in self._model.facts:
+            if hasattr(fact, "qname") and fact.qname is not None:
+                self._facts_by_local_name[fact.qname.localName].add(fact)
+
+    @property
+    def xbrls(self) -> list[ModelXbrl.ModelXbrl]:
+        """Backwards-compatible access to the parsed model as a list."""
+        return [self._model]
 
     def parsed_reports(self) -> list[ModelXbrl.ModelXbrl]:
         """
-        Return the parsed reports from the Arelle session. for querying.
+        Return the parsed reports from the Arelle session for querying.
 
         Returns:
             list[ModelXbrl.ModelXbrl]: A list of parsed reports from the Arelle session.
-
         """
-        return self.xbrls
+        return [self._model]
 
     def _get_datapoints_for_datapoint_code(
         self, datapoint_code: str, esrs_datapoints: dict[str, str]
@@ -108,54 +190,72 @@ class ArelleProcessor:
             for the datapoint. This allows for overriding labels for specific data
             points to provide more accessible copy than the defaults in the ESRS taxonomy.
         """
-        datapoints = []
-        try:
-            res = self.xbrls[0].factsByLocalName.get(datapoint_code)
-            datapoint_readable_label = esrs_datapoints.get(
-                f"esrs:{datapoint_code}", "No label found"
-            )
-            if not res:
-                raise NoMatchingDatapointsError(
-                    f"Could not find datapoint with code {datapoint_code}, for report {self.report_url}",
-                    datapoint_short_code=datapoint_code,
-                    datapoint_readable_label=datapoint_readable_label,
-                )
+        # Resolve the readable label up front so it's always available for error reporting
+        datapoint_readable_label = esrs_datapoints.get(
+            f"esrs:{datapoint_code}", "No label found"
+        )
 
-            for item in res:
-                readable_label = item.propertyView[2][1]
-                # we convert endDatetime and startDatetime to date
-                # even though there is a shorter endDate property. this is
-                # because endDate is handled differently to both datetimes
-                start_date = item.context.startDatetime.date()
-                end_date = item.context.endDatetime.date()
-                document_line_reference = (
-                    f"item.modelDocument.basename - {item.sourceline}"
-                )
-                qname = str(item.qname)
-                value = item.value
+        res = self._facts_by_local_name.get(datapoint_code)
 
-                unit = ""
-                if "Percentage" in qname:
-                    unit = "percentage"
-                    value = float(item.value)
-
-                dp = DataPoint(
-                    name=readable_label,
-                    short_code=datapoint_code,
-                    value=value,
-                    unit=unit,
-                    context=document_line_reference,
-                    file=self.report_url,
-                    start_date=start_date,
-                    end_date=end_date,
-                )
-                datapoints.append(dp)
-        except KeyError:
+        if not res:
             raise NoMatchingDatapointsError(
-                f"Could not find datapoint with code {datapoint_code}",
+                f"Could not find datapoint with code {datapoint_code}, for report {self.report_url}",
                 datapoint_short_code=datapoint_code,
                 datapoint_readable_label=datapoint_readable_label,
             )
+
+        datapoints = []
+        for item in res:
+            # With skipDTS=True, propertyView[2][1] returns the namespace
+            # rather than a human-readable label. We use the label from
+            # our own esrs_datapoints dict instead, stripping the ESRS code prefix.
+            readable_label = datapoint_readable_label
+            # Strip the ESRS reference code prefix (e.g. "E1-5 37 c - ") to get
+            # just the descriptive label, matching the taxonomy label format
+            parts = readable_label.split(" ", 1)
+            if len(parts) > 1:
+                # Find where the descriptive text starts (after code like "E1-5 AR 34")
+                # by looking for the first letter after the numeric/code part
+                for i, ch in enumerate(readable_label):
+                    if ch.isalpha() and i > 0 and readable_label[i - 1] == " ":
+                        # Check if this looks like part of a code (e.g., "AR", "a", "b", "c")
+                        remaining = readable_label[i:]
+                        if (
+                            remaining[0].isupper()
+                            and len(remaining) > 2
+                            and remaining[1].islower()
+                        ):
+                            # This looks like the start of a descriptive phrase
+                            readable_label = remaining
+                            break
+
+            # we convert endDatetime and startDatetime to date
+            # even though there is a shorter endDate property. this is
+            # because endDate is handled differently to both datetimes
+            start_date = item.context.startDatetime.date()
+            end_date = item.context.endDatetime.date()
+            document_line_reference = (
+                f"item.modelDocument.basename - {item.sourceline}"
+            )
+            qname = str(item.qname)
+            value = item.value
+
+            unit = ""
+            if "Percentage" in qname:
+                unit = "percentage"
+                value = float(item.value)
+
+            dp = DataPoint(
+                name=readable_label,
+                short_code=datapoint_code,
+                value=value,
+                unit=unit,
+                context=document_line_reference,
+                file=self.report_url,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            datapoints.append(dp)
 
         return datapoints
 

--- a/tests/test_csrd_prevalidation.py
+++ b/tests/test_csrd_prevalidation.py
@@ -1,0 +1,140 @@
+"""Tests for CSRD pre-validation helpers.
+
+These functions provide fast, cheap checks before invoking the expensive
+Arelle XBRL processor.
+"""
+
+import httpx
+import pytest
+
+from carbon_txt.process_csrd_document import (
+    _looks_like_esef_url,
+    _quick_validate_remote_csrd_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# _looks_like_esef_url
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeEsefUrl:
+    """URL extension heuristic for ESEF-compatible documents."""
+
+    def test_looks_like_esef_xhtml(self):
+        assert _looks_like_esef_url("https://example.com/report.xhtml") is True
+
+    def test_looks_like_esef_xbrl(self):
+        assert _looks_like_esef_url("https://example.com/report.xbrl") is True
+
+    def test_looks_like_esef_xml(self):
+        assert _looks_like_esef_url("https://example.com/report.xml") is True
+
+    def test_looks_like_esef_zip(self):
+        assert _looks_like_esef_url("https://example.com/report.zip") is True
+
+    def test_looks_like_esef_html(self):
+        assert _looks_like_esef_url("https://example.com/report.html") is True
+
+    def test_looks_like_esef_htm(self):
+        assert _looks_like_esef_url("https://example.com/report.htm") is True
+
+    def test_looks_like_esef_extensionless(self):
+        """Extensionless URLs are allowed through (might serve correct content)."""
+        assert _looks_like_esef_url("https://example.com/report") is True
+
+    def test_rejects_pdf(self):
+        assert _looks_like_esef_url("https://example.com/report.pdf") is False
+
+    def test_rejects_csv(self):
+        assert _looks_like_esef_url("https://example.com/data.csv") is False
+
+    def test_rejects_image(self):
+        assert _looks_like_esef_url("https://example.com/logo.png") is False
+
+    def test_case_insensitive(self):
+        """Extension check is case-insensitive."""
+        assert _looks_like_esef_url("https://example.com/REPORT.XHTML") is True
+
+    def test_local_file_path(self):
+        assert _looks_like_esef_url("/path/to/report.xhtml") is True
+
+
+# ---------------------------------------------------------------------------
+# _quick_validate_remote_csrd_url
+# ---------------------------------------------------------------------------
+
+
+class TestQuickValidateRemoteCsrdUrl:
+    """Lightweight HTTP HEAD pre-validation for remote CSRD URLs."""
+
+    def test_prevalidate_local_path_always_passes(self):
+        """Local file paths bypass HTTP checks entirely."""
+        assert _quick_validate_remote_csrd_url("/path/to/file.xhtml") is True
+
+    def test_prevalidate_reachable_xhtml_passes(self, httpx_mock):
+        """A reachable URL with an HTML-family content-type passes."""
+        url = "https://example.com/report.xhtml"
+        httpx_mock.add_response(
+            url=url,
+            method="HEAD",
+            status_code=200,
+            headers={"content-type": "text/html"},
+        )
+        assert _quick_validate_remote_csrd_url(url) is True
+
+    def test_prevalidate_404_fails(self, httpx_mock):
+        """A 404 response causes pre-validation to fail."""
+        url = "https://example.com/missing.xhtml"
+        httpx_mock.add_response(
+            url=url,
+            method="HEAD",
+            status_code=404,
+        )
+        assert _quick_validate_remote_csrd_url(url) is False
+
+    def test_prevalidate_wrong_content_type_fails(self, httpx_mock):
+        """A 200 with an incompatible content-type (e.g. PDF) fails."""
+        url = "https://example.com/report.pdf"
+        httpx_mock.add_response(
+            url=url,
+            method="HEAD",
+            status_code=200,
+            headers={"content-type": "application/pdf"},
+        )
+        assert _quick_validate_remote_csrd_url(url) is False
+
+    def test_prevalidate_empty_content_type_passes(self, httpx_mock):
+        """A 200 with no content-type header is allowed through."""
+        url = "https://example.com/report.xhtml"
+        httpx_mock.add_response(
+            url=url,
+            method="HEAD",
+            status_code=200,
+            # No content-type header
+        )
+        assert _quick_validate_remote_csrd_url(url) is True
+
+    def test_prevalidate_connection_error_fails(self, httpx_mock):
+        """A connection error causes pre-validation to fail."""
+        url = "https://unreachable.example.com/report.xhtml"
+        httpx_mock.add_exception(
+            httpx.ConnectError("Connection refused"),
+            url=url,
+            method="HEAD",
+        )
+        assert _quick_validate_remote_csrd_url(url) is False
+
+    def test_prevalidate_logs_failures(self, httpx_mock):
+        """When a logs list is provided, failures are recorded in it."""
+        url = "https://example.com/gone.xhtml"
+        httpx_mock.add_response(
+            url=url,
+            method="HEAD",
+            status_code=404,
+        )
+        logs = []
+        result = _quick_validate_remote_csrd_url(url, logs=logs)
+        assert result is False
+        assert len(logs) > 0
+        assert "404" in logs[0]

--- a/tests/test_csrd_session_manager.py
+++ b/tests/test_csrd_session_manager.py
@@ -1,0 +1,241 @@
+"""Tests for ArelleSessionManager and ArelleProcessor changes.
+
+These tests exercise the new session reuse infrastructure and the
+modified ArelleProcessor that uses skipDTS + a manual facts index.
+"""
+
+import pathlib
+
+import pytest
+from arelle import ModelXbrl  # type: ignore
+
+from carbon_txt.processors.csrd_document import (
+    ArelleProcessor,
+    ArelleSessionManager,
+    GreenwebCSRDProcessor,
+    get_shared_session_manager,
+    _shared_session_manager,
+)
+from carbon_txt.exceptions import NoLoadableCSRDFile
+
+
+FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures"
+LOCAL_FILE_1 = str(FIXTURE_DIR / "esrs-e1-efrag-2026-12-31-en.xhtml")
+LOCAL_FILE_2 = str(FIXTURE_DIR / "esrs-e2-efrag-2026-12-31-en-no-renewables.xhtml")
+
+
+# ---------------------------------------------------------------------------
+# ArelleSessionManager
+# ---------------------------------------------------------------------------
+
+
+class TestArelleSessionManager:
+    """Tests for the session reuse manager."""
+
+    def test_load_valid_report(self):
+        """load_report() returns a ModelXbrl for a valid local file."""
+        mgr = ArelleSessionManager()
+        try:
+            model = mgr.load_report(LOCAL_FILE_1)
+            assert isinstance(model, ModelXbrl.ModelXbrl)
+        finally:
+            mgr.close()
+
+    def test_raises_on_unloadable_file(self):
+        """load_report() raises NoLoadableCSRDFile for a bad URL."""
+        mgr = ArelleSessionManager()
+        try:
+            with pytest.raises(NoLoadableCSRDFile):
+                mgr.load_report("https://www.example.com/no-csrd-report")
+        finally:
+            mgr.close()
+
+    def test_reuses_session(self):
+        """Calling load_report() twice reuses the same internal session."""
+        mgr = ArelleSessionManager()
+        try:
+            mgr.load_report(LOCAL_FILE_1)
+            session_after_first = mgr._session
+            assert session_after_first is not None
+
+            mgr.load_report(LOCAL_FILE_2)
+            session_after_second = mgr._session
+            assert session_after_second is session_after_first
+        finally:
+            mgr.close()
+
+    def test_loads_multiple_distinct_reports(self):
+        """Two sequential load_report() calls return distinct, valid models."""
+        mgr = ArelleSessionManager()
+        try:
+            model_1 = mgr.load_report(LOCAL_FILE_1)
+            model_2 = mgr.load_report(LOCAL_FILE_2)
+
+            assert model_1 is not model_2
+            assert isinstance(model_1, ModelXbrl.ModelXbrl)
+            assert isinstance(model_2, ModelXbrl.ModelXbrl)
+
+            # Verify they have different fact counts (file 1 is larger)
+            facts_1 = list(model_1.facts)
+            facts_2 = list(model_2.facts)
+            assert len(facts_1) > len(facts_2)
+        finally:
+            mgr.close()
+
+    def test_close_is_idempotent(self):
+        """Calling close() twice does not raise."""
+        mgr = ArelleSessionManager()
+        mgr.load_report(LOCAL_FILE_1)
+        mgr.close()
+        mgr.close()  # should not raise
+
+    def test_recovers_after_close(self):
+        """After close(), a new load_report() creates a fresh session."""
+        mgr = ArelleSessionManager()
+        try:
+            mgr.load_report(LOCAL_FILE_1)
+            mgr.close()
+            assert mgr._session is None
+
+            # Should work again with a new session
+            model = mgr.load_report(LOCAL_FILE_1)
+            assert isinstance(model, ModelXbrl.ModelXbrl)
+            assert mgr._session is not None
+        finally:
+            mgr.close()
+
+
+class TestGetSharedSessionManager:
+    """Tests for the module-level singleton."""
+
+    def test_returns_singleton(self):
+        """get_shared_session_manager() returns the same instance each time."""
+        mgr_1 = get_shared_session_manager()
+        mgr_2 = get_shared_session_manager()
+        assert mgr_1 is mgr_2
+
+
+# ---------------------------------------------------------------------------
+# ArelleProcessor changes
+# ---------------------------------------------------------------------------
+
+
+class TestArelleProcessorChanges:
+    """Tests for the modified ArelleProcessor."""
+
+    def test_accepts_custom_session_manager(self):
+        """ArelleProcessor can be given an explicit session manager."""
+        mgr = ArelleSessionManager()
+        try:
+            processor = ArelleProcessor(LOCAL_FILE_1, session_manager=mgr)
+            assert processor.parsed_reports()
+        finally:
+            mgr.close()
+
+    def test_facts_by_local_name_index_populated(self):
+        """The manual _facts_by_local_name index contains expected codes."""
+        mgr = ArelleSessionManager()
+        try:
+            processor = ArelleProcessor(LOCAL_FILE_1, session_manager=mgr)
+
+            expected_codes = [
+                "PercentageOfRenewableSourcesInTotalEnergyConsumption",
+                "EnergyConsumptionFromRenewableSources",
+                "EnergyConsumptionRelatedToOwnOperations",
+            ]
+            for code in expected_codes:
+                assert code in processor._facts_by_local_name, (
+                    f"{code} not found in facts index"
+                )
+                assert len(processor._facts_by_local_name[code]) > 0
+        finally:
+            mgr.close()
+
+    def test_xbrls_property_backward_compat(self):
+        """The .xbrls property returns a list with one model."""
+        mgr = ArelleSessionManager()
+        try:
+            processor = ArelleProcessor(LOCAL_FILE_1, session_manager=mgr)
+            xbrls = processor.xbrls
+            assert isinstance(xbrls, list)
+            assert len(xbrls) == 1
+            assert isinstance(xbrls[0], ModelXbrl.ModelXbrl)
+        finally:
+            mgr.close()
+
+
+# ---------------------------------------------------------------------------
+# Plugin early-exit paths
+# ---------------------------------------------------------------------------
+
+
+class TestPluginEarlyExit:
+    """Tests for early-exit paths in the process_csrd_document plugin."""
+
+    def test_plugin_skips_non_esef_extension(self):
+        """A csrd-report disclosure with a .pdf URL returns early without Arelle."""
+        from carbon_txt.process_csrd_document import process_document
+        from carbon_txt.schemas.common import Disclosure
+
+        doc = Disclosure(
+            doc_type="csrd-report",
+            url="https://example.com/report.pdf",
+            domain="example.com",
+        )
+        logs = []
+        result = process_document(document=doc, logs=logs)
+
+        # Should return early with just logs, no plugin_name or document_results
+        assert "plugin_name" not in result
+        assert any("ESEF-compatible" in log for log in logs)
+
+    def test_plugin_skips_unreachable_url(self, httpx_mock):
+        """A csrd-report with an unreachable HTTPS URL returns early after HEAD fails."""
+        from carbon_txt.process_csrd_document import process_document
+        from carbon_txt.schemas.common import Disclosure
+
+        url = "https://unreachable.example.com/report.xhtml"
+        httpx_mock.add_response(url=url, method="HEAD", status_code=404)
+
+        doc = Disclosure(
+            doc_type="csrd-report",
+            url=url,
+            domain="unreachable.example.com",
+        )
+        logs = []
+        result = process_document(document=doc, logs=logs)
+
+        assert "plugin_name" not in result
+        assert any("failed pre-validation" in log for log in logs)
+
+    def test_plugin_processes_valid_local_csrd(self):
+        """End-to-end: the plugin processes a local .xhtml file and returns datapoints."""
+        from carbon_txt.process_csrd_document import process_document
+        from carbon_txt.schemas.common import Disclosure
+
+        doc = Disclosure(
+            doc_type="csrd-report",
+            url=LOCAL_FILE_1,
+            domain="test.example.com",
+        )
+        logs = []
+        result = process_document(document=doc, logs=logs)
+
+        assert result["plugin_name"] == "csrd_greenweb"
+        assert len(result["document_results"]) > 0
+
+        # Check we got actual DataPoint objects back
+        from carbon_txt.processors.csrd_document import DataPoint
+        from carbon_txt.exceptions import NoMatchingDatapointsError
+
+        datapoints = [
+            r for r in result["document_results"] if isinstance(r, DataPoint)
+        ]
+        assert len(datapoints) > 0
+        # Verify a known datapoint is present
+        renewable_pct = [
+            dp for dp in datapoints
+            if dp.short_code == "PercentageOfRenewableSourcesInTotalEnergyConsumption"
+        ]
+        assert len(renewable_pct) > 0
+        assert renewable_pct[0].value > 0.2


### PR DESCRIPTION
I created this PR because we have had a number of performance issues relating to passing ESEF formatted CSRD reports. 

I ended up passing these through an LLM to identify some bottlenecks in their performance , to fix them, and it seems to have yielded some decent improvements.

This is still WIP while I test the functionality manually, but assuming these work as advertised it should make the parsing CSRD report functionality _much_ faster when deployed.


---

Auto generated summary of changes from Github

This pull request introduces significant performance improvements and robustness to the CSRD document processing pipeline. The main enhancements are faster report parsing by reusing Arelle sessions and skipping unnecessary taxonomy loading, as well as pre-validating URLs to avoid expensive processing of invalid files. The code also improves fact extraction and label handling for better accuracy and clarity.

**Performance and Resource Management Improvements**
- Introduced an `ArelleSessionManager` class to manage and reuse Arelle sessions, reducing repeated controller and plugin manager initialization for each report. This cuts report load time by ~85% by using `skipDTS=True`. A shared session manager singleton is used across processor instances. [[1]](diffhunk://#diff-ebfd610845ebf601283e9804f514d7ca7c5f5d6c7d6775990a1a86d60b9e8900R37-R116) [[2]](diffhunk://#diff-ebfd610845ebf601283e9804f514d7ca7c5f5d6c7d6775990a1a86d60b9e8900L45-R178)
- Refactored `ArelleProcessor` to use the shared session manager and to build its own index of facts by local name, enabling efficient fact lookup without full taxonomy discovery.

**Robustness and Early Error Detection**
- Added `_looks_like_esef_url` and `_quick_validate_remote_csrd_url` functions to quickly filter out obviously invalid URLs and perform lightweight HTTP HEAD checks before invoking Arelle. This avoids unnecessary processing of unreachable or non-XBRL files and saves startup time. [[1]](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52R16-R21) [[2]](diffhunk://#diff-286f709d100f90f422581a53b019bb5bd0c50bcf19806771bd5f0482fb940f52R32-R105)
- Integrated these pre-validation checks into the `process_document` hook, ensuring only plausible ESEF/iXBRL documents are processed.

**Fact Extraction and Label Handling**
- Improved `_get_datapoints_for_datapoint_code` to use the new local name index for fact retrieval and enhanced label extraction logic to provide cleaner, more descriptive labels, even when skipping taxonomy loading.

**Minor Improvements**
- Fixed typos and improved docstrings for clarity and accuracy.

These changes collectively make CSRD document processing faster, more reliable, and easier to maintain.


---

Auto generated summary of changes from the coding LLM


Performance changes:
- Use skipDTS=True in Arelle RuntimeOptions to skip full taxonomy discovery. Since we only need fact values by local name, the full DTS traversal is unnecessary. This cuts load time from ~2.2s to ~0.3s per report.
- Introduce ArelleSessionManager to reuse Arelle Sessions across multiple report loads, avoiding repeated controller/plugin manager initialisation. Two sequential reports now load in ~0.4s total (vs ~4.4s before).
- Build our own facts-by-local-name index from parsed facts, since Arelle's built-in factsByLocalName requires full DTS.
- Remove double session.close() call (context manager handles it).
- Add HTTP pre-validation in the CSRD plugin: a lightweight HEAD request checks reachability and content-type before invoking Arelle, saving ~2s for obviously invalid URLs.
- Add file extension sniffing to reject obviously non-ESEF URLs (e.g. PDFs, images) before Arelle startup.
- Fix error handling: resolve datapoint_readable_label before the try block to prevent potential UnboundLocalError. Remove overly broad KeyError catch that could mask bugs.
- Use esrs_datapoints dict for readable labels instead of propertyView (which returns namespace with skipDTS=True).

Benchmarks (before -> after):
- Single report load:    2.175s -> 0.281s  (7.7x faster)
- Two sequential loads:  4.354s -> 0.390s  (11.2x faster)
- Bad URL failure:       0.114s -> 0.074s  (1.5x faster)
- Datapoint extraction:  0.072s -> 0.000s  (instant, no first-call penalty)
- Full test suite:      61.45s  -> 1.42s   (43x faster)