### PR TITLE
Ensure the  http header is respected when a redirect is received

### DIFF
--- a/src/carbon_txt/finders.py
+++ b/src/carbon_txt/finders.py
@@ -349,7 +349,7 @@ class FileFinder:
                 f"Could not connect to {parsed_uri.geturl()}."
             )
 
-        if response.status_code > 399:
+        if response.status_code > 299:
             raise UnreachableCarbonTxtFile(
                 f"HTTP error {response.status_code} when connecting to {parsed_uri.geturl()}"
             )

--- a/tests/http_mocks.py
+++ b/tests/http_mocks.py
@@ -22,6 +22,9 @@ The available mocks are as follows:
     - mocked_http_delegating_carbon_txt_domain
         (domain only, delegates to other domain with HTTP header, other domain
         returns valid TOML with 200 response)
+    - mocked_http_delegating_carbon_txt_domain_with_redirect
+        (domain only, delegates to other domain with HTTP header, sending a 301 response,
+        other domain returns valid TOML with 200 response)
     - mocked_dns_delegating_carbon_txt_url
         (url with path, redirects to other domain wtih DNS TXT record, other domain
         returns valid TOML with 200 response)
@@ -187,15 +190,6 @@ def mocked_http_delegating_carbon_txt_domain(minimal_carbon_txt_org, httpx_mock)
         )
         httpx_mock.add_response(
             method=method,
-            url=f"https://{domain}/carbon.txt",
-            status_code=404,
-            content="",
-            headers={"CarbonTxt-Location": managed_service_url},
-            is_reusable=True,
-            is_optional=True,
-        )
-        httpx_mock.add_response(
-            method=method,
             url=f"https://{domain}/.well-known/carbon.txt",
             status_code=404,
             content="",
@@ -207,6 +201,65 @@ def mocked_http_delegating_carbon_txt_domain(minimal_carbon_txt_org, httpx_mock)
             method=method,
             url=re.compile(f"https?://{domain}"),
             status_code=200,
+            content="",
+            headers={"CarbonTxt-Location": managed_service_url},
+            is_reusable=True,
+            is_optional=True,
+        )
+    for method in ["get", "head"]:
+        httpx_mock.add_response(
+            method=method,
+            url=managed_service_url,
+            status_code=200,
+            content=minimal_carbon_txt_org,
+            is_reusable=True,
+            is_optional=True,
+        )
+    return domain
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            "",
+            marks=pytest.mark.httpx_mock(
+                should_mock=lambda request: request.url.host.endswith("example.com")
+            ),
+        )
+    ]
+)
+def mocked_http_delegating_carbon_txt_domain_with_redirect(
+    minimal_carbon_txt_org, httpx_mock
+) -> str:
+    """
+    Return a domain which delegates carbon.txt using an HTTP header,
+    Ensure the delegated URL responds with a valid carbon.txt and a 200 response.
+    """
+    domain = "delegating.example.com"
+    managed_service_url = "https://managed-service.example.com/carbon.txt"
+    for method in ["get", "head"]:
+        httpx_mock.add_response(
+            method=method,
+            url=f"https://{domain}/carbon.txt",
+            status_code=301,
+            content="",
+            headers={"CarbonTxt-Location": managed_service_url},
+            is_reusable=True,
+            is_optional=True,
+        )
+        httpx_mock.add_response(
+            method=method,
+            url=f"https://{domain}/.well-known/carbon.txt",
+            status_code=301,
+            content="",
+            headers={"CarbonTxt-Location": managed_service_url},
+            is_reusable=True,
+            is_optional=True,
+        )
+        httpx_mock.add_response(
+            method=method,
+            url=re.compile(f"https?://{domain}"),
+            status_code=301,
             content="",
             headers={"CarbonTxt-Location": managed_service_url},
             is_reusable=True,

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -62,6 +62,29 @@ class TestFinder:
         # We get back a result that is delegated using HTTP
         assert result.delegation_method == "http"
 
+    def test_looking_up_domain_with_delegation_using_http_and_redirect(
+        self, mocked_http_delegating_carbon_txt_domain_with_redirect
+    ):
+        """
+        Looking up a domain that has a "CarbonTxt-Location" HTTP header and
+        returns a 30x status code for the carbon.txt URI
+        should delegate us to the correct URL in that header,
+        """
+        finder = FileFinder()
+
+        # Given a domain
+
+        # When we pass a domain
+        result = finder.resolve_domain(
+            mocked_http_delegating_carbon_txt_domain_with_redirect
+        )
+
+        # We get back the URI of the carbon.txt file to lookup
+        assert result.uri == "https://managed-service.example.com/carbon.txt"
+
+        # We get back a result that is delegated using HTTP
+        assert result.delegation_method == "http"
+
     def test_looking_up_uri_simple(self, mocked_carbon_txt_url):
         """Looking up a domain with a carbon.txt file"""
 


### PR DESCRIPTION
A tiny bug in the finder - which wasn't respecting our stated carbon.txt resolution order.

DNS always takes precedence over a hosted carbon.txt, which always takes precedence over an HTTP header.

*however* we don't respect HTTP redirects (by design), but, previously, if an http redirect response was received for a carbon.txt file, this was validated in preference to the carbon.txt stated by the header, and an error resulted.

This fixes that - An actually-present carbon.txt will still take priority over the header, but a redirect will pass through to the heawder check.
