### PR TITLE
python 3.11 compatability bugfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Pin to selected version:
+      - name: Pin to selected version
         run: uv python pin ${{ matrix.python-version }}
 
       - name: Install tooling for managing dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Pin to selected version:
+        run: uv python pin ${{ matrix.python-version }}
+
       - name: Install tooling for managing dependencies
         run: uv sync
 

--- a/src/carbon_txt/processors/ai_model_card.py
+++ b/src/carbon_txt/processors/ai_model_card.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Optional
+from typing import Callable, Optional, TypeAlias
 
 import frontmatter
 from mistletoe import Document
@@ -50,7 +50,7 @@ class FieldSpec(BaseModel):
     unit: str | None
 
 
-type AIModelCardResponse = DataPoint | NoMatchingDatapointsError
+AIModelCardResponse : TypeAlias = DataPoint | NoMatchingDatapointsError
 
 
 class GreenwebAIModelCardProcessor:

--- a/src/carbon_txt/schemas/version_0_5.py
+++ b/src/carbon_txt/schemas/version_0_5.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, TypeAlias
 
 from .common import (
     Organisation,
@@ -8,7 +8,7 @@ from .common import (
 from .version_0_4 import CarbonTxtFile as CarbonTxtFileV4, Disclosure as DisclosureV4
 
 
-type SpecificDisclosureDocType = Literal[SpecificDisclosureDocTypeV4, "ai-model-card"]
+SpecificDisclosureDocType : TypeAlias = Literal[SpecificDisclosureDocTypeV4, "ai-model-card"]
 
 
 class Disclosure(DisclosureV4):


### PR DESCRIPTION
Our Python 3.11 CI runner wasn't actually using 3.11, and some bugs crept in. This fixes both things: the bugs, and the CI misconfiguration.