### PR TITLE
Add API key authentication

### DIFF
--- a/.github/workflows/run-deploy.yml
+++ b/.github/workflows/run-deploy.yml
@@ -44,3 +44,6 @@ jobs:
           CARBON_TXT_API_GIT_BRANCH: prod
           CARBON_TXT_API_SERVICE_NAME: carbon_txt_api
           CARBON_TXT_API_HOSTNAME: carbon-txt-api.greenweb.org
+          CARBON_TXT_GWF_SHARED_SECRET: ${{ secrets.CARBON_TXT_GWF_SHARED_SECRET }}
+          CARBON_TXT_API_KEY_INTROSPECTION_URL: ${{ secrets.CARBON_TXT_API_KEY_INTROSPECTION_URL }}
+          CARBON_TXT_REQUIRE_API_KEY: ${{ secrets.CARBON_TXT_REQUIRE_API_KEY }}

--- a/.github/workflows/run-staging-deploy.yml
+++ b/.github/workflows/run-staging-deploy.yml
@@ -44,3 +44,6 @@ jobs:
           CARBON_TXT_API_GIT_BRANCH: staging
           CARBON_TXT_API_SERVICE_NAME: staging_carbon_txt_api
           CARBON_TXT_API_HOSTNAME: staging-carbon-txt-api.greenweb.org
+          CARBON_TXT_GWF_SHARED_SECRET: ${{ secrets.CARBON_TXT_GWF_SHARED_SECRET }}
+          CARBON_TXT_API_KEY_INTROSPECTION_URL: ${{ secrets.CARBON_TXT_API_KEY_INTROSPECTION_URL }}
+          CARBON_TXT_REQUIRE_API_KEY: ${{ secrets.CARBON_TXT_REQUIRE_API_KEY }}

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -13,6 +13,9 @@
 
     # Environment variables for carbon.txt.api
     secret_key: "{{ lookup('env', 'CARBON_TXT_API_SECRET_KEY') | string }}"
+    gwf_shared_secret: "{{ lookup('env', 'CARBON_TXT_GWF_SHARED_SECRET') | string }}"
+    api_key_introspection_url: "{{ lookup('env', 'CARBON_TXT_API_KEY_INTROSPECTION_URL') | string }}"
+    require_api_key: "{{ lookup('env', 'CARBON_TXT_REQUIRE_API_KEY') | string }}"
     database_url: "{{ lookup('env', 'CARBON_TXT_API_DATABASE_URL') | string }}"
     api_port: "{{ lookup('env', 'CARBON_TXT_API_PORT') | string }}"
     git_branch: "{{ lookup('env', 'CARBON_TXT_API_GIT_BRANCH') | string }}"

--- a/ansible/playbooks/templates/carbon_txt_api_dotenv.sh.j2
+++ b/ansible/playbooks/templates/carbon_txt_api_dotenv.sh.j2
@@ -3,7 +3,9 @@
 
 SECRET_KEY="{{ secret_key }}"
 DATABASE_URL="{{ database_url }}"
-
+GWF_SHARED_SECRET="{{ gwf_shared_secret }}"
+API_KEY_INTROSPECTION_URL="{{ api_key_introspection_url }}"
+REQUIRE_API_KEY="{{ require_api_key }}"
 # We default to having this, to avoid needing to set it every time
 ACTIVE_CARBON_TXT_PLUGINS="carbon_txt.process_csrd_document,carbon_txt.process_ai_model_card"
 

--- a/ansible/playbooks/templates/run_carbon_txt_api.sh.j2
+++ b/ansible/playbooks/templates/run_carbon_txt_api.sh.j2
@@ -1,6 +1,7 @@
 /home/deploy/.cargo/bin/uv tool run \
     --with mysqlclient \
     --from git+https://github.com/thegreenwebfoundation/carbon-txt-validator/\#{{ git_branch }} \
+    --reinstall \
     carbon-txt serve \
     --django-settings local_config \
     --port {{ api_port }} \

--- a/ansible/playbooks/templates/run_carbon_txt_api.sh.j2
+++ b/ansible/playbooks/templates/run_carbon_txt_api.sh.j2
@@ -1,6 +1,6 @@
 /home/deploy/.cargo/bin/uv tool run \
     --with mysqlclient \
-    --from git+https://github.com/thegreenwebfoundation/carbon-txt-validator/\#{{ git_branch }} \
+    --from git+https://github.com/thegreenwebfoundation/carbon-txt-validator/@{{ git_branch }} \
     --reinstall \
     carbon-txt serve \
     --django-settings local_config \

--- a/src/carbon_txt/processors/ai_model_card.py
+++ b/src/carbon_txt/processors/ai_model_card.py
@@ -50,7 +50,7 @@ class FieldSpec(BaseModel):
     unit: str | None
 
 
-AIModelCardResponse : TypeAlias = DataPoint | NoMatchingDatapointsError
+AIModelCardResponse: TypeAlias = DataPoint | NoMatchingDatapointsError
 
 
 class GreenwebAIModelCardProcessor:

--- a/src/carbon_txt/schemas/version_0_5.py
+++ b/src/carbon_txt/schemas/version_0_5.py
@@ -8,7 +8,9 @@ from .common import (
 from .version_0_4 import CarbonTxtFile as CarbonTxtFileV4, Disclosure as DisclosureV4
 
 
-SpecificDisclosureDocType : TypeAlias = Literal[SpecificDisclosureDocTypeV4, "ai-model-card"]
+SpecificDisclosureDocType: TypeAlias = Literal[
+    SpecificDisclosureDocTypeV4, "ai-model-card"
+]
 
 
 class Disclosure(DisclosureV4):

--- a/src/carbon_txt/web/api.py
+++ b/src/carbon_txt/web/api.py
@@ -6,6 +6,7 @@ from ninja import NinjaAPI, Schema
 import structlog
 
 from .. import exceptions, finders, schemas, validators  # noqa
+from .api_key_auth import APIKeyHeaderAuth, APIKeyQueryAuth
 
 file_finder = finders.FileFinder()
 
@@ -22,6 +23,7 @@ ninja_api = NinjaAPI(
             "termsOfService": "https://thegreenwebfoundation.org/terms/",
         }
     },
+    auth=[APIKeyHeaderAuth(), APIKeyQueryAuth()],
     title="Carbon.txt Validator API",
     description="This is the API for validating carbon.txt files. ",
 )

--- a/src/carbon_txt/web/api.py
+++ b/src/carbon_txt/web/api.py
@@ -6,7 +6,7 @@ from ninja import NinjaAPI, Schema
 import structlog
 
 from .. import exceptions, finders, schemas, validators  # noqa
-from .api_key_auth import APIKeyHeaderAuth, APIKeyQueryAuth
+from .api_key_auth import APIKeyHeaderAuth
 
 file_finder = finders.FileFinder()
 
@@ -23,7 +23,7 @@ ninja_api = NinjaAPI(
             "termsOfService": "https://thegreenwebfoundation.org/terms/",
         }
     },
-    auth=[APIKeyHeaderAuth(), APIKeyQueryAuth()],
+    auth=[APIKeyHeaderAuth()],
     title="Carbon.txt Validator API",
     description="This is the API for validating carbon.txt files. ",
 )

--- a/src/carbon_txt/web/api_key_auth.py
+++ b/src/carbon_txt/web/api_key_auth.py
@@ -1,7 +1,7 @@
 import httpx
 from django.conf import settings
 from django.http import HttpRequest
-from ninja.security import APIKeyHeader, APIKeyQuery
+from ninja.security import APIKeyHeader
 from structlog import get_logger
 
 logger = get_logger()
@@ -16,16 +16,34 @@ def introspect_key(key: str | None) -> dict | None:
         return {"active": True}
     if key:
         try:
+            prefix, _ = key.split(".")
             resp = httpx.post(
                 settings.API_KEY_INTROSPECTION_URL,
                 json={"token": key},
                 headers={"X-GWF-Shared-Secret": settings.GWF_SHARED_SECRET},
+                timeout=5.0,
             )
+            resp.raise_for_status()
             body = resp.json()
+            logger.exception(body)
             if body["active"]:
                 return body
+
+        except httpx.HTTPStatusError as ex:
+            # A non-200 respoonse from the introspection API
+            logger.error(f"Introspection returned {ex.response.status_code} for key prefix {prefix}: {ex}")
+        except httpx.HTTPError as ex:
+            # A lower-level network error
+            logger.error(f"Network error contacting introspection endpoint for key prefix {prefix}: {ex}")
+        except KeyError as ex:
+            # The request returned JSON without an "active" key
+            logger.error(f"Malformed introspection response for key prefix {prefix}: {ex}")
+        except ValueError:
+            # This is raised in the call to key.split - GWF keys are in the
+            # format gwf_xxxxxx.xxxxx.. - so this isn't a real one.
+            logger.exception(f"Malformed API key provided: \"{key[0:10]}...\"")
         except Exception as ex:
-            prefix, _ = key.split(".")
+            # Anything else that might go wrong - we err on the side of caution.
             logger.exception(
                 f"Unexpected error authorizing key with prefix {prefix}: {ex}"
             )
@@ -34,13 +52,6 @@ def introspect_key(key: str | None) -> dict | None:
 
 class APIKeyHeaderAuth(APIKeyHeader):
     param_name = "X-Api-Key"
-
-    def authenticate(self, request: HttpRequest, key: str) -> dict | None:
-        return introspect_key(key)
-
-
-class APIKeyQueryAuth(APIKeyQuery):
-    param_name = "api_key"
 
     def authenticate(self, request: HttpRequest, key: str) -> dict | None:
         return introspect_key(key)

--- a/src/carbon_txt/web/api_key_auth.py
+++ b/src/carbon_txt/web/api_key_auth.py
@@ -1,0 +1,46 @@
+import httpx
+from django.conf import settings
+from django.http import HttpRequest
+from ninja.security import APIKeyHeader, APIKeyQuery
+from structlog import get_logger
+
+logger = get_logger()
+
+
+def introspect_key(key: str | None) -> dict | None:
+    """
+    Hands off to the admin portal API key introspection API to authorize
+    the user's API key if authentication is enabled.
+    """
+    if not settings.REQUIRE_API_KEY:
+        return {"active": True}
+    if key:
+        try:
+            resp = httpx.post(
+                settings.API_KEY_INTROSPECTION_URL,
+                json={"token": key},
+                headers={"X-GWF-Shared-Secret": settings.GWF_SHARED_SECRET},
+            )
+            body = resp.json()
+            if body["active"]:
+                return body
+        except Exception as ex:
+            prefix, _ = key.split(".")
+            logger.exception(
+                f"Unexpected error authorizing key with prefix {prefix}: {ex}"
+            )
+    return None
+
+
+class APIKeyHeaderAuth(APIKeyHeader):
+    param_name = "X-Api-Key"
+
+    def authenticate(self, request: HttpRequest, key: str) -> dict | None:
+        return introspect_key(key)
+
+
+class APIKeyQueryAuth(APIKeyQuery):
+    param_name = "api_key"
+
+    def authenticate(self, request: HttpRequest, key: str) -> dict | None:
+        return introspect_key(key)

--- a/src/carbon_txt/web/api_key_auth.py
+++ b/src/carbon_txt/web/api_key_auth.py
@@ -25,7 +25,6 @@ def introspect_key(key: str | None) -> dict | None:
             )
             resp.raise_for_status()
             body = resp.json()
-            logger.exception(body)
             if body["active"]:
                 return body
 

--- a/src/carbon_txt/web/config/settings/base.py
+++ b/src/carbon_txt/web/config/settings/base.py
@@ -44,6 +44,9 @@ env = environ.Env(
     ACTIVE_CARBON_TXT_PLUGINS=(list, []),
     DEFAULT_CARBON_TXT_PLUGINS=(list, DEFAULT_CARBON_TXT_PLUGINS),
     DATABASE_URL=(str, DEFAULT_DATABASE_URL),
+    GWF_SHARED_SECRET=(str, os.getenv("GWF_SHARED_SECRET")),
+    API_KEY_INTROSPECTION_URL=(str, os.getenv("API_KEY_INTROSPECTION_URL")),
+    REQUIRE_API_KEY=(bool, False),
 )
 
 # fetch environment variables from .env file
@@ -75,6 +78,10 @@ if env("SECRET_KEY") == DEFAULT_SECRET_KEY:
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env("SECRET_KEY")
+
+GWF_SHARED_SECRET = env("GWF_SHARED_SECRET")
+API_KEY_INTROSPECTION_URL = env("API_KEY_INTROSPECTION_URL")
+REQUIRE_API_KEY = env("REQUIRE_API_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")

--- a/tests/test_api_key_auth.py
+++ b/tests/test_api_key_auth.py
@@ -1,0 +1,189 @@
+import json
+
+import httpx
+
+
+def test_all_requests_allowed_when_auth_not_required(
+    mocker, live_server, mocked_carbon_txt_url
+):
+    """
+    When API key auth is switched off, all requests are allowed.
+    """
+
+    # GIVEN API key auth is switched off
+    mock_settings = mocker.patch("carbon_txt.web.api_key_auth.settings")
+    mock_settings.REQUIRE_API_KEY = False
+
+    # WHEN I make a request without an API key
+    api_url = f"{live_server.url}/api/validate/url"
+    data = {"url": mocked_carbon_txt_url}
+    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
+
+    # THEN I get a succesful response
+    assert res.status_code == 200
+
+
+def test_unauthorized_request_not_allowed_when_auth_required(
+    mocker, live_server, mocked_carbon_txt_url
+):
+    """
+    When API key auth is switched on, unauthorized requests are not allowed.
+    """
+
+    # GIVEN API key auth is switched on
+    mock_settings = mocker.patch("carbon_txt.web.api_key_auth.settings")
+    mock_settings.REQUIRE_API_KEY = True
+
+    # WHEN I make an unauthorized request
+    api_url = f"{live_server.url}/api/validate/url"
+    data = {"url": mocked_carbon_txt_url}
+    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
+
+    # THEN I receive an unauthorized response
+    assert res.status_code == 401
+
+
+def test_authorized_request_with_valid_key_in_query_string_allowed_when_auth_required(
+    mocker, httpx_mock, live_server, mocked_carbon_txt_url
+):
+    """
+    When API key auth is switched on, authorized requests
+    with a valid API key in the query string are allowed.
+    """
+
+    # GIVEN API key auth is switched on
+    mock_settings = mocker.patch("carbon_txt.web.api_key_auth.settings")
+    mock_settings.REQUIRE_API_KEY = True
+    mock_settings.API_KEY_INTROSPECTION_URL = "http://example.com/introspect"
+    mock_settings.GWF_SHARED_SECRET = "def456"
+
+    httpx_mock.add_response(
+        url=mock_settings.API_KEY_INTROSPECTION_URL, json={"active": True}
+    )
+
+    # WHEN I make a request with an authorized token in the query string
+    api_key = "abc123"
+    api_url = f"{live_server.url}/api/validate/url?api_key={api_key}"
+    data = {"url": mocked_carbon_txt_url}
+    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
+
+    request = httpx_mock.get_requests()[0]
+    body = json.loads(request.content)
+
+    # THEN I get a succesful response
+    assert res.status_code == 200
+
+    # AND the introspection API is called correctly
+    assert request.headers["X-GWF-Shared-Secret"] == mock_settings.GWF_SHARED_SECRET
+    assert body["token"] == api_key
+
+
+def test_authorized_request_with_valid_key_in_header_allowed_when_auth_required(
+    mocker, httpx_mock, live_server, mocked_carbon_txt_url
+):
+    """
+    When API key auth is switched on, authorized requests
+    with a valid API key in the request headers are allowed.
+    """
+
+    # GIVEN API key auth is switched on
+    mock_settings = mocker.patch("carbon_txt.web.api_key_auth.settings")
+    mock_settings.REQUIRE_API_KEY = True
+    mock_settings.API_KEY_INTROSPECTION_URL = "http://example.com/introspect"
+    mock_settings.GWF_SHARED_SECRET = "def456"
+
+    httpx_mock.add_response(
+        url=mock_settings.API_KEY_INTROSPECTION_URL, json={"active": True}
+    )
+
+    # WHEN I make a request with an authorized token in the request headers
+    api_key = "abc123"
+    api_url = f"{live_server.url}/api/validate/url"
+    data = {"url": mocked_carbon_txt_url}
+    headers = {"X-Api-Key": api_key}
+    res = httpx.post(
+        api_url, json=data, headers=headers, follow_redirects=True, timeout=None
+    )
+
+    request = httpx_mock.get_requests()[0]
+    body = json.loads(request.content)
+
+    # THEN I get a succesful response
+    assert res.status_code == 200
+
+    # AND the introspection API is called correctly
+    assert request.headers["X-GWF-Shared-Secret"] == mock_settings.GWF_SHARED_SECRET
+    assert body["token"] == api_key
+
+
+def test_authorized_request_with_invalid_key_in_query_string_not_allowed_when_auth_required(
+    mocker, httpx_mock, live_server, mocked_carbon_txt_url
+):
+    """
+    When API key auth is switched on, authorized requests
+    with an invalid API key in the query string are not allowed.
+    """
+
+    # GIVEN API key auth is switched on
+    mock_settings = mocker.patch("carbon_txt.web.api_key_auth.settings")
+    mock_settings.REQUIRE_API_KEY = True
+    mock_settings.API_KEY_INTROSPECTION_URL = "http://example.com/introspect"
+    mock_settings.GWF_SHARED_SECRET = "def456"
+
+    httpx_mock.add_response(
+        url=mock_settings.API_KEY_INTROSPECTION_URL, json={"active": False}
+    )
+
+    # When I make a request with an unauthorized token in the query string
+    api_key = "abc123"
+    api_url = f"{live_server.url}/api/validate/url?api_key={api_key}"
+    data = {"url": mocked_carbon_txt_url}
+    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
+
+    request = httpx_mock.get_requests()[0]
+    body = json.loads(request.content)
+
+    # THEN I receive un unauthorized response
+    assert res.status_code == 401
+
+    # AND the introspection API is called correctly
+    assert request.headers["X-GWF-Shared-Secret"] == mock_settings.GWF_SHARED_SECRET
+    assert body["token"] == api_key
+
+
+def test_authorized_request_with_invalid_key_in_header_not_allowed_when_auth_required(
+    mocker, httpx_mock, live_server, mocked_carbon_txt_url
+):
+    """
+    When API key auth is switched on, authorized requests
+    with an invalid API key in the request headers are not allowed.
+    """
+
+    # GIVEN API key auth is switched on
+    mock_settings = mocker.patch("carbon_txt.web.api_key_auth.settings")
+    mock_settings.REQUIRE_API_KEY = True
+    mock_settings.API_KEY_INTROSPECTION_URL = "http://example.com/introspect"
+    mock_settings.GWF_SHARED_SECRET = "def456"
+
+    httpx_mock.add_response(
+        url=mock_settings.API_KEY_INTROSPECTION_URL, json={"active": False}
+    )
+
+    # When I make a request with an unauthorized token in the request headers
+    api_key = "abc123"
+    api_url = f"{live_server.url}/api/validate/url"
+    data = {"url": mocked_carbon_txt_url}
+    headers = {"X-Api-Key": api_key}
+    res = httpx.post(
+        api_url, json=data, headers=headers, follow_redirects=True, timeout=None
+    )
+
+    request = httpx_mock.get_requests()[0]
+    body = json.loads(request.content)
+
+    # THEN I receive un unauthorized response
+    assert res.status_code == 401
+
+    # AND the introspection API is called correctly
+    assert request.headers["X-GWF-Shared-Secret"] == mock_settings.GWF_SHARED_SECRET
+    assert body["token"] == api_key

--- a/tests/test_api_key_auth.py
+++ b/tests/test_api_key_auth.py
@@ -43,41 +43,6 @@ def test_unauthorized_request_not_allowed_when_auth_required(
     assert res.status_code == 401
 
 
-def test_authorized_request_with_valid_key_in_query_string_allowed_when_auth_required(
-    mocker, httpx_mock, live_server, mocked_carbon_txt_url
-):
-    """
-    When API key auth is switched on, authorized requests
-    with a valid API key in the query string are allowed.
-    """
-
-    # GIVEN API key auth is switched on
-    mock_settings = mocker.patch("carbon_txt.web.api_key_auth.settings")
-    mock_settings.REQUIRE_API_KEY = True
-    mock_settings.API_KEY_INTROSPECTION_URL = "http://example.com/introspect"
-    mock_settings.GWF_SHARED_SECRET = "def456"
-
-    httpx_mock.add_response(
-        url=mock_settings.API_KEY_INTROSPECTION_URL, json={"active": True}
-    )
-
-    # WHEN I make a request with an authorized token in the query string
-    api_key = "abc123"
-    api_url = f"{live_server.url}/api/validate/url?api_key={api_key}"
-    data = {"url": mocked_carbon_txt_url}
-    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
-
-    request = httpx_mock.get_requests()[0]
-    body = json.loads(request.content)
-
-    # THEN I get a succesful response
-    assert res.status_code == 200
-
-    # AND the introspection API is called correctly
-    assert request.headers["X-GWF-Shared-Secret"] == mock_settings.GWF_SHARED_SECRET
-    assert body["token"] == api_key
-
-
 def test_authorized_request_with_valid_key_in_header_allowed_when_auth_required(
     mocker, httpx_mock, live_server, mocked_carbon_txt_url
 ):
@@ -97,7 +62,7 @@ def test_authorized_request_with_valid_key_in_header_allowed_when_auth_required(
     )
 
     # WHEN I make a request with an authorized token in the request headers
-    api_key = "abc123"
+    api_key = "gwf_abc123.def456"
     api_url = f"{live_server.url}/api/validate/url"
     data = {"url": mocked_carbon_txt_url}
     headers = {"X-Api-Key": api_key}
@@ -110,41 +75,6 @@ def test_authorized_request_with_valid_key_in_header_allowed_when_auth_required(
 
     # THEN I get a succesful response
     assert res.status_code == 200
-
-    # AND the introspection API is called correctly
-    assert request.headers["X-GWF-Shared-Secret"] == mock_settings.GWF_SHARED_SECRET
-    assert body["token"] == api_key
-
-
-def test_authorized_request_with_invalid_key_in_query_string_not_allowed_when_auth_required(
-    mocker, httpx_mock, live_server, mocked_carbon_txt_url
-):
-    """
-    When API key auth is switched on, authorized requests
-    with an invalid API key in the query string are not allowed.
-    """
-
-    # GIVEN API key auth is switched on
-    mock_settings = mocker.patch("carbon_txt.web.api_key_auth.settings")
-    mock_settings.REQUIRE_API_KEY = True
-    mock_settings.API_KEY_INTROSPECTION_URL = "http://example.com/introspect"
-    mock_settings.GWF_SHARED_SECRET = "def456"
-
-    httpx_mock.add_response(
-        url=mock_settings.API_KEY_INTROSPECTION_URL, json={"active": False}
-    )
-
-    # When I make a request with an unauthorized token in the query string
-    api_key = "abc123"
-    api_url = f"{live_server.url}/api/validate/url?api_key={api_key}"
-    data = {"url": mocked_carbon_txt_url}
-    res = httpx.post(api_url, json=data, follow_redirects=True, timeout=None)
-
-    request = httpx_mock.get_requests()[0]
-    body = json.loads(request.content)
-
-    # THEN I receive un unauthorized response
-    assert res.status_code == 401
 
     # AND the introspection API is called correctly
     assert request.headers["X-GWF-Shared-Secret"] == mock_settings.GWF_SHARED_SECRET
@@ -170,7 +100,79 @@ def test_authorized_request_with_invalid_key_in_header_not_allowed_when_auth_req
     )
 
     # When I make a request with an unauthorized token in the request headers
-    api_key = "abc123"
+    api_key = "gwf_abc123.def456"
+    api_url = f"{live_server.url}/api/validate/url"
+    data = {"url": mocked_carbon_txt_url}
+    headers = {"X-Api-Key": api_key}
+    res = httpx.post(
+        api_url, json=data, headers=headers, follow_redirects=True, timeout=None
+    )
+
+    request = httpx_mock.get_requests()[0]
+    body = json.loads(request.content)
+
+    # THEN I receive un unauthorized response
+    assert res.status_code == 401
+
+    # AND the introspection API is called correctly
+    assert request.headers["X-GWF-Shared-Secret"] == mock_settings.GWF_SHARED_SECRET
+    assert body["token"] == api_key
+
+def test_authorized_request_with_key_with_invalid_format_in_header_not_allowed_when_auth_required(
+    mocker, httpx_mock, live_server, mocked_carbon_txt_url
+):
+    """
+    When API key auth is switched on, authorized requests
+    with a malformed API key in the request headers are not allowed.
+    """
+
+    # GIVEN API key auth is switched on
+    mock_settings = mocker.patch("carbon_txt.web.api_key_auth.settings")
+    mock_settings.REQUIRE_API_KEY = True
+    mock_settings.API_KEY_INTROSPECTION_URL = "http://example.com/introspect"
+    mock_settings.GWF_SHARED_SECRET = "def456"
+
+    httpx_mock.add_response(
+        url=mock_settings.API_KEY_INTROSPECTION_URL, json={"active": True}, is_optional=True
+    )
+
+    # When I make a request with a malformattedtoken in the request headers
+    api_key = "abc123def456"
+    api_url = f"{live_server.url}/api/validate/url"
+    data = {"url": mocked_carbon_txt_url}
+    headers = {"X-Api-Key": api_key}
+    res = httpx.post(
+        api_url, json=data, headers=headers, follow_redirects=True, timeout=None
+    )
+
+    # THEN I receive un unauthorized response
+    assert res.status_code == 401
+
+    # AND the introspection API is not called
+    assert len(httpx_mock.get_requests()) == 0
+
+
+def test_authorized_request_with_error_on_introspection_not_allowed_when_auth_required(
+    mocker, httpx_mock, live_server, mocked_carbon_txt_url
+):
+    """
+    When API key auth is switched on, authorized requests where the introspection API
+    does not return the expected response are not allowed.
+    """
+
+    # GIVEN API key auth is switched on
+    mock_settings = mocker.patch("carbon_txt.web.api_key_auth.settings")
+    mock_settings.REQUIRE_API_KEY = True
+    mock_settings.API_KEY_INTROSPECTION_URL = "http://example.com/introspect"
+    mock_settings.GWF_SHARED_SECRET = "def456"
+
+    # AND the introspection API returns an error response
+    httpx_mock.add_response(
+        url=mock_settings.API_KEY_INTROSPECTION_URL, json={"details": "An error message"}, status_code=500
+    )
+
+    # When I make a request with a token in the request headers
+    api_key = "gwf_abc123.def456"
     api_url = f"{live_server.url}/api/validate/url"
     data = {"url": mocked_carbon_txt_url}
     headers = {"X-Api-Key": api_key}


### PR DESCRIPTION
This adds API key authentication, backed by an internal key introspection API endpoint on the admin portal app.

API keys may be passed in the query string with the api_key parameter, or with the X-Api-Key http header.

Authentication is only enabled if the REQUIRE_API_KEY environment variable is set.

The environment variables API_KEY_INTROSPECTION_URL and GWF_SHARED_SECRET configure the authorization logic - the shared secret is used to authenticate to the portal server.