### PR TITLE
optional dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: uv python pin ${{ matrix.python-version }}
 
       - name: Install tooling for managing dependencies
-        run: uv sync
+        run: uv sync --all-extras
 
       - name: Run tests
         run: just ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ Fixed, Changed, Added, Removed, Fixed, Security
 
 ## Unreleased
 
+### Added
+
+- ADR-05 documenting the decision and tradeoffs for splitting optional dependencies into extras `[csrd]` and `[web]`.
+- `scripts/verify_extras.py` for manual verification of each install variant (core, `[csrd]`, `[web]`, `[all]`).
+
+### Changed
+
+- **BREAKING**: Dependencies have been split into optional extras. The base `carbon-txt` package now installs only core dependencies (~22 MB). The web server (`carbon-txt serve`) requires the `[web]` extra, and CSRD report processing requires the `[csrd]` extra.
+- **BREAKING**: `GreenwebCSRDProcessor` is no longer exported from `carbon_txt.processors`. Import it directly from `carbon_txt.processors.csrd_document` instead.
+- Replaced `django-environ` with `os.environ` in the core CLI for reading plugin configuration, removing the Django dependency from the core install.
+- Migrated `[tool.uv] dev-dependencies` to the modern `[dependency-groups] dev` format (PEP 735).
+- Moved `django-stubs[compatible-mypy]` from the `[web]` extra into the `dev` dependency group.
+
+### Fixed
+
+- `docs/conf.py` path resolution bug when building documentation outside the project root.
+
 ## [0.0.27]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ Fixed, Changed, Added, Removed, Fixed, Security
 
 ### Changed
 
-- **BREAKING**: Dependencies have been split into optional extras. The base `carbon-txt` package now installs only core dependencies (~22 MB). The web server (`carbon-txt serve`) requires the `[web]` extra, and CSRD report processing requires the `[csrd]` extra.
+- **BREAKING**: Dependencies have been split into optional extras. The base `carbon-txt` package now installs only core dependencies (~22 MB). The web server (`carbon-txt serve`) requires the `[web]` extra, CSRD report processing requires the `[csrd]` extra, and AI model card parsing require the `[ai_model_cards]` extra.
 - **BREAKING**: `GreenwebCSRDProcessor` is no longer exported from `carbon_txt.processors`. Import it directly from `carbon_txt.processors.csrd_document` instead.
+- **BREAKING**: `GreenwebAIModelCardProcessor` is no longer exported from `carbon_txt.processors`. Import it directly from `carbon_txt.processors.ai_model_card` instead.
 - Replaced `django-environ` with `os.environ` in the core CLI for reading plugin configuration, removing the Django dependency from the core install.
 - Migrated `[tool.uv] dev-dependencies` to the modern `[dependency-groups] dev` format (PEP 735).
 - Moved `django-stubs[compatible-mypy]` from the `[web]` extra into the `dev` dependency group.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The carbon.txt validator is split into optional extras so you only install what 
 | `carbon-txt` | Core library and CLI (~22 MB) |
 | `carbon-txt[web]` | Core + Django web server |
 | `carbon-txt[csrd]` | Core + Arelle for CSRD report processing |
+| `carbon-txt[ai_model_cards]` | Core + mistletoe/frontmatter for AI model card processing |
 | `carbon-txt[all]` | Everything |
 
 ## Using `pip`
@@ -79,6 +80,9 @@ python -m pip install "carbon-txt[web]"
 
 # With CSRD report processing
 python -m pip install "carbon-txt[csrd]"
+
+# With AI model card processing
+python -m pip install "carbon-txt[ai_model_cards]"
 
 # Everything
 python -m pip install "carbon-txt[all]"
@@ -102,6 +106,9 @@ uv add "carbon-txt[web]"
 
 # With CSRD report processing
 uv add "carbon-txt[csrd]"
+
+# With AI model card processing
+uv add "carbon-txt[ai_model_cards]"
 
 # Everything
 uv add "carbon-txt[all]"

--- a/README.md
+++ b/README.md
@@ -55,15 +55,33 @@ Please see the [dedicated documentation site for the validator](https://carbon-t
 
 # Installation
 
-> [!TIP]
-> See more detailed [guidance on installation on the dedicated valiator docs site](https://carbon-txt-validator.readthedocs.io/en/latest/installation.html).
+> [!TIP]> See more detailed [guidance on installation on the dedicated valiator docs site](https://carbon-txt-validator.readthedocs.io/en/latest/installation.html).
+
+The carbon.txt validator is split into optional extras so you only install what you need:
+
+| Install target | Use case |
+|---------------|---------|
+| `carbon-txt` | Core library and CLI (~22 MB) |
+| `carbon-txt[web]` | Core + Django web server |
+| `carbon-txt[csrd]` | Core + Arelle for CSRD report processing |
+| `carbon-txt[all]` | Everything |
 
 ## Using `pip`
 
 You can install the latest release of the carbon.txt validator using pip. we assume that the carbon.txt validator is run inside a virtual environment. [Learn more about virtual environments with Python](https://realpython.com/python-virtual-environments-a-primer/).
 
-```
+```shell
+# Core only: CLI validation tool
 python -m pip install carbon-txt
+
+# With web server support
+python -m pip install "carbon-txt[web]"
+
+# With CSRD report processing
+python -m pip install "carbon-txt[csrd]"
+
+# Everything
+python -m pip install "carbon-txt[all]"
 ```
 
 
@@ -75,8 +93,18 @@ project, and the one we actively support.
 
 Add carbon-txt to a project with `uv add`:
 
-```
+```shell
+# Core only
 uv add carbon-txt
+
+# With web server support
+uv add "carbon-txt[web]"
+
+# With CSRD report processing
+uv add "carbon-txt[csrd]"
+
+# Everything
+uv add "carbon-txt[all]"
 ```
 
 You can now run the command line tool with `uv run carbon-txt`
@@ -85,15 +113,15 @@ You can now run the command line tool with `uv run carbon-txt`
 
 If you have uv installed, you can run the command line tool like so:
 
-```
-# check a file
+```shell
+# Core validation commands (validate, schema, plugins)
 uv tool run carbon-txt validate ./path/to/file
 
-# run a server
-uv tool run carbon-txt serve
+# Run a server (requires the [web] extra)
+uv tool run --with "carbon-txt[web]" carbon-txt serve
 ```
 
-This will download the latest published version from [Pypi](https://pypi.org/) and run the corresponding CLI command
+This will download the latest published version from [Pypi](https://pypi.org/) and run the corresponding CLI command.
 
 Further details are in the [dedicated docs on read the docs for the validator](https://carbon-txt-validator.readthedocs.io/en/latest/index.html)
 

--- a/ansible/playbooks/templates/run_carbon_txt_api.sh.j2
+++ b/ansible/playbooks/templates/run_carbon_txt_api.sh.j2
@@ -1,6 +1,7 @@
 /home/deploy/.cargo/bin/uv tool run \
     --with mysqlclient \
-    --from git+https://github.com/thegreenwebfoundation/carbon-txt-validator/@{{ git_branch }} \
+    --with "carbon-txt[all]" \
+    --from git+https://github.com/thegreenwebfoundation/carbon-txt-validator@{{ git_branch }} \
     --reinstall \
     carbon-txt serve \
     --django-settings local_config \

--- a/docs/adrs/05_optional_dependencies.md
+++ b/docs/adrs/05_optional_dependencies.md
@@ -17,7 +17,7 @@ The `carbon-txt` validator has grown to support three distinct use cases:
 Historically, all three were bundled into a single install target. This meant that a user who only wanted to validate `carbon.txt` syntax from the command line would still pull in Django (~30 MB), Granian (~16 MB), Arelle (~24 MB), NumPy (~21 MB), lxml (~20 MB), Pillow (~13 MB), and all their transitive dependencies. The total installed footprint exceeded **300 MB** even for the simplest use case.
 
 This created friction for:
-- CI pipelines that only need to validate files
+- Data Pipelines that only need to validate files
 - Embedded/library consumers who want a small dependency tree
 - Deployment environments where disk space or security audit surface matters
 
@@ -130,7 +130,7 @@ carbon-txt serve --django-settings myproject.settings
 
 ### What becomes easier
 
-- **Smaller CI pipelines**: Core validation runs in ~22 MB instead of 300+ MB
+- **Smaller Data pipelines**: Core validation pulls in ~22 MB instead of 300+ MB
 - **Faster installs**: Fewer compiled dependencies to fetch and link
 - **Reduced security audit surface**: Production deployments don't include Django or Arelle unless needed
 - **Clearer dependency intent**: `requirements.txt` or `pyproject.toml` dependencies communicate which features are used

--- a/docs/adrs/05_optional_dependencies.md
+++ b/docs/adrs/05_optional_dependencies.md
@@ -1,0 +1,151 @@
+
+
+# ADR 5: Splitting carbon-txt into optional dependency extras for smaller, focused installs
+
+## Status
+
+Accepted
+
+## Context
+
+The `carbon-txt` validator has grown to support three distinct use cases:
+
+1. **Core library**: Parsing and validating `carbon.txt` files as a library or CLI tool
+2. **CSRD processing**: Using Arelle to parse XBRL/CSRD sustainability reports linked from `carbon.txt`
+3. **Web service**: Running a Django-based HTTP API for validation-as-a-service
+
+Historically, all three were bundled into a single install target. This meant that a user who only wanted to validate `carbon.txt` syntax from the command line would still pull in Django (~30 MB), Granian (~16 MB), Arelle (~24 MB), NumPy (~21 MB), lxml (~20 MB), Pillow (~13 MB), and all their transitive dependencies. The total installed footprint exceeded **300 MB** even for the simplest use case.
+
+This created friction for:
+- CI pipelines that only need to validate files
+- Embedded/library consumers who want a small dependency tree
+- Deployment environments where disk space or security audit surface matters
+
+## Decision
+
+**Split the package into optional dependency extras using standard PEP 508 `[extras]` syntax, while keeping a single source tree and wheel.**
+
+We define three install targets:
+
+| Target | Command | What you get |
+|--------|---------|-------------|
+| **Core** | `uv pip install carbon-txt` | Parser, validator, CLI, AI model card processor |
+| **CSRD** | `uv pip install "carbon-txt[csrd]"` | Core + Arelle + CSRD report processing |
+| **Web** | `uv pip install "carbon-txt[web]"` | Core + Django + Granian + web API |
+| **All** | `uv pip install "carbon-txt[all]"` | Convenience alias for `[csrd,web]` |
+
+### Key design choices
+
+1. **One wheel, runtime guards**: We publish a single `carbon-txt` wheel that contains all source files. Heavy imports (Django, Arelle) are deferred to runtime inside `try/except` blocks. This is the standard Python packaging convention — `pip install package[extra]` adds dependencies, it does not change wheel contents.
+
+2. **CSRD is a peer plugin**: `GreenwebCSRDProcessor` is no longer eagerly exported from `carbon_txt.processors`. It must be imported explicitly from `carbon_txt.processors.csrd_document`, mirroring how external plugins would be consumed.
+
+3. **CLI guards the `serve` command**: Running `carbon-txt serve` without `[web]` installed produces a clear error message directing the user to install the extra.
+
+4. **Environment variable parsing without django-environ**: The core CLI no longer depends on `django-environ`. Plugin configuration is read directly from `os.environ`, removing a Django-affinity dependency from the core install.
+
+5. **Dev dependencies migrated to `[dependency-groups]`**: The `[tool.uv] dev-dependencies` section was converted to the PEP 735 `[dependency-groups] dev` format, which is the modern standard and works cleanly with `uv sync`.
+
+### Installed size comparison
+
+| Variant | Total Size | Packages Installed |
+|---------|-----------|-------------------|
+| **Core only** | **22 MB** | 33 |
+| **CSRD** | **107 MB** | ~52 |
+| **Web** | **152 MB** | ~53 |
+| **All** | **237 MB** | 72 |
+
+#### Top 5 contributors by variant
+
+| Rank | Core (22M) | CSRD (107M) | Web (152M) | All (237M) |
+|------|-----------|-------------|------------|------------|
+| 1 | `pygments` (4.9M) | `arelle` (24M) | `mypyc` .so (39M) | `mypyc` .so (39M) |
+| 2 | `pydantic_core` (4.2M) | `numpy` (21M) | `django` (30M) | `django` (30M) |
+| 3 | `pydantic` (1.9M) | `lxml` (20M) | `mypy` (17M) | `arelle` (24M) |
+| 4 | `rich` (1.4M) | `Pillow` (13M) | `granian` (16M) | `numpy` (21M) |
+| 5 | `dns` (1.3M) | `pygments` (4.9M) | `ninja` (9M) | `lxml` (20M) |
+
+The default `carbon-txt` install is now **~90% smaller** than before (22 MB vs ~300 MB).
+
+### Usage examples
+
+#### Validate a carbon.txt file from the command line (core only)
+
+```bash
+uv pip install carbon-txt
+carbon-txt validate file ./carbon.txt
+```
+
+Or programmatically:
+
+```python
+from carbon_txt.validators import CarbonTxtValidator
+
+validator = CarbonTxtValidator()
+result = validator.validate_url("https://example.com/carbon.txt")
+
+if result.result:
+    print("Valid!")
+    print(result.result)
+else:
+    print("Invalid:", result.exceptions)
+```
+
+#### Process a CSRD report linked from a carbon.txt file
+
+```bash
+uv pip install "carbon-txt[csrd]"
+```
+
+```python
+from carbon_txt.processors.csrd_document import GreenwebCSRDProcessor
+
+processor = GreenwebCSRDProcessor(report_url="https://example.com/report.xhtml")
+datapoints = processor.get_esrs_datapoint_values(processor.local_datapoint_codes)
+
+for dp in datapoints:
+    print(f"{dp.short_code}: {dp.value} {dp.unit}")
+```
+
+#### Run the validation web service
+
+```bash
+uv pip install "carbon-txt[web]"
+carbon-txt serve --port 8000
+```
+
+Or with Granian in production:
+
+```bash
+carbon-txt serve --production --server granian
+```
+
+The Django settings module can be overridden:
+
+```bash
+carbon-txt serve --django-settings myproject.settings
+```
+
+## Consequences
+
+### What becomes easier
+
+- **Smaller CI pipelines**: Core validation runs in ~22 MB instead of 300+ MB
+- **Faster installs**: Fewer compiled dependencies to fetch and link
+- **Reduced security audit surface**: Production deployments don't include Django or Arelle unless needed
+- **Clearer dependency intent**: `requirements.txt` or `pyproject.toml` dependencies communicate which features are used
+- **Standard Python UX**: `pip install package[extra]` is familiar to Python users
+
+### What becomes more difficult
+
+- **Single wheel contains all files**: The wheel includes `web/` and `csrd_document.py` even for core installs. However, these are pure-Python source files (~40 KB combined) and do not affect runtime behaviour due to import guards. The real savings are in dependency exclusion.
+
+- **One extra cannot see another's imports**: A project that installs `[csrd]` but not `[web]` cannot accidentally use Django features, and vice versa. This is usually desired, but could confuse users who expect all submodules to be importable after any install.
+
+- **Testing matrix expansion**: We now need to verify behaviour across four install variants. A `scripts/verify_extras.py` script was added to support this.
+
+### Future considerations
+
+- The `[web]` extra previously included `django-stubs[compatible-mypy]`, which pulled in `mypy` (~17 MB) — a development tool, not a runtime dependency. Moving type stubs to `dev` dependencies reduced the web variant footprint.
+
+- If installed size of source files themselves (not dependencies) becomes a genuine constraint, the next step would be to split into separate installable packages (e.g. `carbon-txt-core`, `carbon-txt-web`, `carbon-txt-csrd`) using uv workspaces or a monorepo structure. This is significantly more complex and not justified at current sizes.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ project = "Carbon.txt Validator"
 copyright = "2024, Chris Adams, Fershad Irani, Hannah Smith"
 author = "Chris Adams, Fershad Irani, Hannah Smith"
 
-pypproject_toml = pathlib.Path(".").absolute().parent / "pyproject.toml"
+pypproject_toml = pathlib.Path(__file__).parent.parent / "pyproject.toml"
 parsed_toml = tomllib.loads(pypproject_toml.read_text())
 
 release = parsed_toml["project"]["version"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,6 +8,19 @@ For convenience, the carbon.txt validator has a `serve` command that
 spins up the default bundled Django server. This is fine for development, but
 for production, we also bundle in Granian, a more performant server.
 
+```{admonition} Requires the [web] extra
+:class: important
+
+Running the validator as a server requires Django and Granian, which are part
+of the `[web]` extra. For a full deployment including CSRD processing, install
+everything with the `[all]` extra:
+
+```shell
+pip install "carbon-txt[all]"
+```
+
+```
+
 For local hosting you might run the development server like so:
 
 ```shell

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,8 +8,9 @@ The validator is split into optional extras so you only install what you need:
 
 | Install target | What is included | Use case |
 |---------------|------------------|---------|
-| `carbon-txt` | Core library, CLI, and AI model card plugin (~22 MB) | Validating files, building tools |
+| `carbon-txt` | Core library, CLI, and AI model card plugin (~15.6 MB) | Validating files, building tools |
 | `carbon-txt[csrd]` | Core + Arelle for XBRL/CSRD parsing (~107 MB) | Processing CSRD sustainability reports |
+| `carbon-txt[ai_model_cards]` | Core + misteltoe / frontmatter for YAML parsing (~6.4 MB) | Processing AI model cards |
 | `carbon-txt[web]` | Core + Django + Granian web server (~152 MB) | Running the validation API |
 | `carbon-txt[all]` | Everything above | Development or full deployments |
 
@@ -24,6 +25,9 @@ python -m pip install "carbon-txt[web]"
 
 # With CSRD report processing
 python -m pip install "carbon-txt[csrd]"
+
+# With AI model card processing
+python -m pip install "carbon-txt[ai_model_cards]"
 
 # Everything
 python -m pip install "carbon-txt[all]"
@@ -44,6 +48,9 @@ uv add "carbon-txt[web]"
 
 # With CSRD report processing
 uv add "carbon-txt[csrd]"
+
+# With AI model card processing
+uv add "carbon-txt[ai_model_cards]"
 
 # Everything
 uv add "carbon-txt[all]"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,8 +1,67 @@
 # Installation
 
-The carbon-txt validator project uses the Pyproject format to track software library dependencies, so should work with most python tools for managing dependencies, like `pip`.
+The carbon-txt validator project uses the Pyproject format to track software library dependencies, so should work with most python tools for managing dependencies, like `pip` or `uv`.
 
-## The supported approach - using `uv` and `just`
+## Optional dependency extras
+
+The validator is split into optional extras so you only install what you need:
+
+| Install target | What is included | Use case |
+|---------------|------------------|---------|
+| `carbon-txt` | Core library, CLI, and AI model card plugin (~22 MB) | Validating files, building tools |
+| `carbon-txt[csrd]` | Core + Arelle for XBRL/CSRD parsing (~107 MB) | Processing CSRD sustainability reports |
+| `carbon-txt[web]` | Core + Django + Granian web server (~152 MB) | Running the validation API |
+| `carbon-txt[all]` | Everything above | Development or full deployments |
+
+### Installing with `pip`
+
+```shell
+# Core only — CLI validation tool
+python -m pip install carbon-txt
+
+# With web server support
+python -m pip install "carbon-txt[web]"
+
+# With CSRD report processing
+python -m pip install "carbon-txt[csrd]"
+
+# Everything
+python -m pip install "carbon-txt[all]"
+```
+
+### Installing with `uv`
+
+`uv` is the recommended tool for managing dependencies, and the one we actively support.
+
+Add carbon-txt to a project:
+
+```shell
+# Core only
+uv add carbon-txt
+
+# With web server support
+uv add "carbon-txt[web]"
+
+# With CSRD report processing
+uv add "carbon-txt[csrd]"
+
+# Everything
+uv add "carbon-txt[all]"
+```
+
+Run without adding to a project:
+
+```shell
+# Core commands: validate, schema, plugins
+uv tool run carbon-txt validate ./path/to/file
+
+# Serve (requires the [web] extra)
+uv tool run --with "carbon-txt[web]" carbon-txt serve
+```
+
+## The supported approach for development - using `uv` and `just`
+
+The supported, 'golden path' for development is to use `uv` for managing dependencies, and `just` for automating common tasks.
 
 With that in mind, the supported, 'golden path' approach is to use the `uv` tool from Astral for managing dependencies, and `just` for automating common tasks.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -47,7 +47,13 @@ This page shows how to use the validator to query these reports for specific kin
 
 ### `carbon-txt-greenweb-ai-model-card` - the 'Green Web AI Model Card' plugin
 
-The AI model card plugin for the carbon.txt validator is one of the default plugins bundled in with the validator. The [source code for the plugin](https://github.com/thegreenwebfoundation/carbon-txt-validator/blob/main/src/carbon_txt/process_ai_model_card.py) as is [the processor it uses to parse reports](https://github.com/thegreenwebfoundation/carbon-txt-validator/blob/main/src/carbon_txt/processors/ai_model_card.py).
+The AI model card plugin for the carbon.txt validator is bundled with the validator, but **requires the `[ai_model_cards]` extra** to be installed:
+
+```shell
+pip install "carbon-txt[ai_model_cards]"
+```
+
+The [source code for the plugin](https://github.com/thegreenwebfoundation/carbon-txt-validator/blob/main/src/carbon_txt/process_ai_model_card.py) as is [the processor it uses to parse reports](https://github.com/thegreenwebfoundation/carbon-txt-validator/blob/main/src/carbon_txt/processors/ai_model_card.py).
 
 ```{admonition} Info
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -18,7 +18,19 @@ Some plugins are bundled into the main carbon.txt validator package, but others 
 
 ### `carbon-txt-greenweb-csrd` - the 'Green Web CSRD' plugin
 
-The CSRD plugin for the carbon.txt validator is one of the default plugins bundled in with the validator. The [source code for the plugin](https://github.com/thegreenwebfoundation/carbon-txt-validator/blob/main/src/carbon_txt/process_csrd_document.py) as is [the CSRD processor it uses to parse reports](https://github.com/thegreenwebfoundation/carbon-txt-validator/blob/main/src/carbon_txt/processors/csrd_document.py). Under the hood, it uses [Arelle, a report parsing tool certified by the XBRL Foundation](https://arelle.readthedocs.io).
+The CSRD plugin for the carbon.txt validator is bundled with the validator, but **requires the `[csrd]` extra** to be installed:
+
+```shell
+pip install "carbon-txt[csrd]"
+```
+
+The [source code for the plugin](https://github.com/thegreenwebfoundation/carbon-txt-validator/blob/main/src/carbon_txt/process_csrd_document.py) and [the CSRD processor it uses to parse reports](https://github.com/thegreenwebfoundation/carbon-txt-validator/blob/main/src/carbon_txt/processors/csrd_document.py) are both part of the package. Under the hood, it uses [Arelle, a report parsing tool certified by the XBRL Foundation](https://arelle.readthedocs.io).
+
+When importing the `GreenwebCSRDProcessor` directly, use:
+
+```python
+from carbon_txt.processors.csrd_document import GreenwebCSRDProcessor
+```
 
 ```{admonition} Info
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -35,12 +35,16 @@ It also uses a `local_config` file - this can be used to add extra configuration
 # written to /var/www/carbon-txt-api.greenweb.org/run_carbon_txt_api.sh
 
 # Inject any extra libraries needed for database connectivity here, eg mysqlclient;
-/path/to/bin/uv tool --with mysqlclient run carbon-txt@latest serve \
---django-settings local_config \
---port <PORT> \
---host <HOST> \
---server granian \
---migrate
+# The [all] extra installs both the web server (Django + Granian) and the CSRD processor (Arelle).
+/path/to/bin/uv tool run \
+    --with mysqlclient \
+    --with "carbon-txt[all]" \
+    carbon-txt serve \
+    --django-settings local_config \
+    --port <PORT> \
+    --host <HOST> \
+    --server granian \
+    --migrate
 ```
 
 The local config file is templated out into the the same directory as where the command is run from. and the same directory as the environment variables file:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -197,8 +197,20 @@ cat ./path-to-file.com | carbon-txt validate file
 
 #### Using the carbon.txt validator as a server
 
-Finally, almost all of the functions of the carbon.txt validator are available over an HTTP API too. Run `carbon-txt serve` to start an API server, with OpenAPI compliant documentation of each endpoint:
+Finally, almost all of the functions of the carbon.txt validator are available over an HTTP API too.
 
+```{admonition} Requires the [web] extra
+:class: important
+
+The `serve` command requires the `[web]` extra to be installed. Install it with:
+
+```shell
+pip install "carbon-txt[web]"
+```
+
+```
+
+Run `carbon-txt serve` to start an API server, with OpenAPI compliant documentation of each endpoint:
 
 ```shell
 carbon-txt serve

--- a/docs/using_plugins.md
+++ b/docs/using_plugins.md
@@ -6,7 +6,20 @@
 
 By default, the carbon.txt validator does not run with any plugins activated.
 
-You can run the validator as a *server*, which exposes its functionality over an API. Running the command below
+You can run the validator as a *server*, which exposes its functionality over an API. 
+
+```{admonition} Requires the [web] extra
+:class: important
+
+The `serve` command requires Django, which is part of the `[web]` extra. Install it first:
+
+```shell
+pip install "carbon-txt[web]"
+```
+
+```
+
+Running the command below:
 
 ```text
 carbon-txt serve
@@ -81,6 +94,17 @@ Should return output, that (once formatted) similar to the JSON below:
 
 
 ### Usage with core plugins - extending functionality with the Greenweb CSRD plugin
+
+```{admonition} Requires the [csrd] extra
+:class: important
+
+Processing CSRD reports requires Arelle, which is part of the `[csrd]` extra. The web server additionally requires the `[web]` extra. For both, use:
+
+```shell
+pip install "carbon-txt[csrd,web]"
+```
+
+```
 
 ```{admonition} Info
 :class: info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,27 +13,32 @@ readme = "README.md"
 requires-python = ">=3.11"
 classifiers = ["License :: OSI Approved :: Apache Software License"]
 dependencies = [
-    "arelle-release>=2.36.3",
-    "django-cors-headers>=4.6.0",
-    "django-environ>=0.11.2",
-    "django-ninja>=1.3.0",
-    "django-structlog>=9.0.0",
-    "django-stubs[compatible-mypy]>=5.1.1",
     "dnspython>=2.7.0",
-    "granian>=1.6.2",
     "httpx>=0.27.2",
     "mistletoe>=1.5.1",
     "pluggy>=1.5.0",
     "pydantic-extra-types>=2.10.3",
     "python-frontmatter>=1.1.0",
     "rich>=13.9.2",
-    "sentry-sdk[django]>=2.18.0",
-    # faster, but not yet supported by python 3.13 yet
-    # "rtoml>=0.11.0",
+    "structlog>=25.3.0",
     "tldextract>=5.3.0",
     "tomlkit>=0.14.0",
     "typer>=0.12.5",
 ]
+
+[project.optional-dependencies]
+csrd = [
+    "arelle-release>=2.36.3",
+]
+web = [
+    "django-cors-headers>=4.6.0",
+    "django-environ>=0.11.2",
+    "django-ninja>=1.3.0",
+    "django-structlog>=9.0.0",
+    "granian>=1.6.2",
+    "sentry-sdk[django]>=2.18.0",
+]
+all = ["carbon-txt[csrd,web]"]
 
 [project.scripts]
 carbon-txt = "carbon_txt.cli:app"
@@ -43,8 +48,8 @@ carbon-txt = "carbon_txt.cli:app"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ipdb>=0.13.13",
     "mypy>=1.12.0",
     "pytest-django>=4.9.0",
@@ -60,4 +65,5 @@ dev-dependencies = [
     "pytest-httpx>=0.34.0",
     "pytest-mock>=3.14.0",
     "ansible>=11.5.0",
+    "django-stubs[compatible-mypy]>=5.1.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    "carbon-txt[all]",
     "ipdb>=0.13.13",
     "mypy>=1.12.0",
     "pytest-django>=4.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,8 @@ classifiers = ["License :: OSI Approved :: Apache Software License"]
 dependencies = [
     "dnspython>=2.7.0",
     "httpx>=0.27.2",
-    "mistletoe>=1.5.1",
     "pluggy>=1.5.0",
     "pydantic-extra-types>=2.10.3",
-    "python-frontmatter>=1.1.0",
     "rich>=13.9.2",
     "structlog>=25.3.0",
     "tldextract>=5.3.0",
@@ -38,7 +36,14 @@ web = [
     "granian>=1.6.2",
     "sentry-sdk[django]>=2.18.0",
 ]
-all = ["carbon-txt[csrd,web]"]
+
+ai_model_cards = [
+    "python-frontmatter>=1.1.0",
+    "mistletoe>=1.5.1",
+]
+
+
+all = ["carbon-txt[csrd,web,ai_model_cards]"]
 
 [project.scripts]
 carbon-txt = "carbon_txt.cli:app"

--- a/scripts/verify_extras.py
+++ b/scripts/verify_extras.py
@@ -54,6 +54,11 @@ def check_core_negative():
             "GreenwebCSRDProcessor should not be importable from processors without [csrd]"
         )
 
+    if _module_available("carbon_txt.processors.ai_model_card"):
+        errors.append(
+            "GreenwebAIModelCardProcessor should not be importable from processors without [ai_model_card]"
+        )
+
     if _module_available("django"):
         errors.append("Django should not be importable without [web]")
 
@@ -78,6 +83,28 @@ def check_csrd():
         errors.append("Core validator broken with CSRD extra")
 
     return errors
+
+
+def check_ai_model_cards():
+    """Verify AI model cards extra is installed and functional."""
+    errors = []
+
+    if not _module_available("carbon_txt.processors.ai_model_card"):
+        errors.append("AI Model Card processor not available")
+
+    if not _module_available("mistletoe"):
+        errors.append("mistletoe not available")
+
+    if not _module_available("frontmatter"):
+        errors.append("frontmatter not available")
+
+    # Core should still work
+    if not _module_available("carbon_txt.validators"):
+        errors.append("Core validator broken with CSRD extra")
+
+    return errors
+
+
 
 
 def check_web():
@@ -113,7 +140,7 @@ def main():
     )
     parser.add_argument(
         "--variant",
-        choices=["core", "csrd", "web", "all"],
+        choices=["core", "csrd", "ai_model_cards", "web", "all"],
         default="all",
         help="Which variant to check (default: all)",
     )
@@ -146,6 +173,17 @@ def main():
     if args.variant in ("csrd", "all"):
         print("Checking CSRD variant...")
         errors = check_csrd()
+        if errors:
+            print(f"  FAIL: {len(errors)} error(s)")
+            for err in errors:
+                print(f"    - {err}")
+            all_errors.extend(errors)
+        else:
+            print("  PASS")
+
+    if args.variant in ("ai_model_cards", "all"):
+        print("Checking AI model card variant...")
+        errors = check_ai_model_cards()
         if errors:
             print(f"  FAIL: {len(errors)} error(s)")
             for err in errors:

--- a/scripts/verify_extras.py
+++ b/scripts/verify_extras.py
@@ -1,0 +1,177 @@
+"""
+Verification script for optional dependency extras.
+
+This script checks that the package works correctly with different combinations
+of optional dependencies installed.
+
+Usage:
+    # Check only the currently installed variant
+    uv run --no-project --with '.[all]' python scripts/verify_extras.py
+
+Or for specific isolated variants:
+    uv run --no-project --with '.' python scripts/verify_extras.py --variant core
+    uv run --no-project --with '.[csrd]' python scripts/verify_extras.py --variant csrd
+    uv run --no-project --with '.[web]' python scripts/verify_extras.py --variant web
+
+Note: When running --variant all, it assumes all extras are installed and
+skips the negative checks (i.e., it won't check that django/arelle are absent).
+"""
+
+import argparse
+import importlib
+import sys
+
+
+def _module_available(name: str) -> bool:
+    """Check if a module is available without importing it."""
+    spec = importlib.util.find_spec(name)
+    return spec is not None
+
+
+def check_core():
+    """Verify core functionality without optional extras."""
+    errors = []
+
+    # These should always work
+    if not _module_available("carbon_txt"):
+        errors.append("carbon_txt module not available")
+    if not _module_available("carbon_txt.validators"):
+        errors.append("carbon_txt.validators not available")
+    if not _module_available("carbon_txt.schemas"):
+        errors.append("carbon_txt.schemas not available")
+    if not _module_available("carbon_txt.processors"):
+        errors.append("carbon_txt.processors not available")
+
+    return errors
+
+
+def check_core_negative():
+    """Verify optional deps are NOT present. Only run in isolated core mode."""
+    errors = []
+
+    if _module_available("carbon_txt.processors.csrd_document"):
+        errors.append(
+            "GreenwebCSRDProcessor should not be importable from processors without [csrd]"
+        )
+
+    if _module_available("django"):
+        errors.append("Django should not be importable without [web]")
+
+    if _module_available("arelle"):
+        errors.append("arelle should not be importable without [csrd]")
+
+    return errors
+
+
+def check_csrd():
+    """Verify CSRD extra is installed and functional."""
+    errors = []
+
+    if not _module_available("carbon_txt.processors.csrd_document"):
+        errors.append("CSRD processor not available")
+
+    if not _module_available("arelle"):
+        errors.append("arelle not available")
+
+    # Core should still work
+    if not _module_available("carbon_txt.validators"):
+        errors.append("Core validator broken with CSRD extra")
+
+    return errors
+
+
+def check_web():
+    """Verify Web extra is installed and functional."""
+    errors = []
+
+    # Must set Django settings before importing ninja
+    import os
+
+    os.environ.setdefault(
+        "DJANGO_SETTINGS_MODULE", "carbon_txt.web.config.settings.test"
+    )
+
+    if not _module_available("django"):
+        errors.append("Django not available")
+    else:
+        import django
+
+        django.setup()
+        if not _module_available("carbon_txt.web.api"):
+            errors.append("Web API not available")
+
+    # Core should still work
+    if not _module_available("carbon_txt.validators"):
+        errors.append("Core validator broken with Web extra")
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify carbon-txt optional dependencies"
+    )
+    parser.add_argument(
+        "--variant",
+        choices=["core", "csrd", "web", "all"],
+        default="all",
+        help="Which variant to check (default: all)",
+    )
+    args = parser.parse_args()
+
+    all_errors = []
+
+    if args.variant in ("core", "all"):
+        print("Checking core variant...")
+        errors = check_core()
+        if errors:
+            print(f"  FAIL: {len(errors)} error(s)")
+            for err in errors:
+                print(f"    - {err}")
+            all_errors.extend(errors)
+        else:
+            print("  PASS")
+
+    if args.variant == "core":
+        print("Checking core negative constraints (no extras present)...")
+        errors = check_core_negative()
+        if errors:
+            print(f"  FAIL: {len(errors)} error(s)")
+            for err in errors:
+                print(f"    - {err}")
+            all_errors.extend(errors)
+        else:
+            print("  PASS")
+
+    if args.variant in ("csrd", "all"):
+        print("Checking CSRD variant...")
+        errors = check_csrd()
+        if errors:
+            print(f"  FAIL: {len(errors)} error(s)")
+            for err in errors:
+                print(f"    - {err}")
+            all_errors.extend(errors)
+        else:
+            print("  PASS")
+
+    if args.variant in ("web", "all"):
+        print("Checking Web variant...")
+        errors = check_web()
+        if errors:
+            print(f"  FAIL: {len(errors)} error(s)")
+            for err in errors:
+                print(f"    - {err}")
+            all_errors.extend(errors)
+        else:
+            print("  PASS")
+
+    if all_errors:
+        print(f"\nTotal failures: {len(all_errors)}")
+        sys.exit(1)
+    else:
+        print("\nAll checks passed!")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/carbon_txt/cli.py
+++ b/src/carbon_txt/cli.py
@@ -5,14 +5,10 @@ import subprocess
 import sys
 from typing import Optional
 
-import django
-import environ  # type: ignore
 import pydantic_core
 import rich
 import structlog
 import typer
-from django.core.management import execute_from_command_line
-from django.conf import settings
 
 from . import exceptions, log_config, schemas, validators  # noqa
 
@@ -31,6 +27,25 @@ app.add_typer(
 err_console = rich.console.Console(stderr=True)
 
 
+def _plugins_from_env() -> tuple[Optional[list[str]], Optional[str]]:
+    """
+    Read plugin configuration from environment variables.
+    Returns a tuple of (active_plugins, plugins_dir).
+    """
+    active_plugins = None
+    plugins_dir = None
+
+    active_plugins_raw = os.environ.get("ACTIVE_CARBON_TXT_PLUGINS", "").strip()
+    if active_plugins_raw:
+        active_plugins = [p.strip() for p in active_plugins_raw.split(",") if p.strip()]
+
+    plugins_dir = os.environ.get("CARBON_TXT_PLUGINS_DIR", None)
+    if plugins_dir:
+        plugins_dir = plugins_dir.strip() or None
+
+    return active_plugins, plugins_dir
+
+
 def create_validator(
     plugins_dir: Optional[str], active_plugins: Optional[list[str]]
 ) -> validators.CarbonTxtValidator:
@@ -38,19 +53,13 @@ def create_validator(
     Return a CarbonTxtValidator instance with the given `plugins_dir` and `active_plugins` values set
     from environment variables if not provided via the function arguments.
     """
-    # we can't rely on values in the django settings module being set at this point.
-    # We might also want to run multiple plugins. So, we need to parse a string
-    # like "my_plugin,my_other_plugin" into a list two strings
-    env = environ.Env(
-        ACTIVE_CARBON_TXT_PLUGINS=(list, []),
-        CARBON_TXT_PLUGINS_DIR=(str, None),
-    )
+    env_active_plugins, env_plugins_dir = _plugins_from_env()
 
     if not active_plugins:
-        active_plugins = env("ACTIVE_CARBON_TXT_PLUGINS")
+        active_plugins = env_active_plugins
 
     if not plugins_dir:
-        plugins_dir = env("CARBON_TXT_PLUGINS_DIR")
+        plugins_dir = env_plugins_dir
 
     validator = validators.CarbonTxtValidator(
         plugins_dir=plugins_dir, active_plugins=active_plugins
@@ -170,15 +179,31 @@ def schema(version: str = schemas.LATEST_VERSION):
     raise typer.Exit(code=0)
 
 
+def _check_web_deps():
+    """Check that the 'web' extra dependencies are installed."""
+    try:
+        import django
+        from django.core.management import execute_from_command_line
+        from django.conf import settings
+        import environ  # type: ignore
+    except ImportError:
+        rich.print("[bold red]The 'web' extra is not installed.[/bold red]")
+        print("Install it with: uv pip install 'carbon-txt[web]'")
+        raise typer.Exit(code=1)
+    return django, settings, execute_from_command_line, environ
+
+
 def configure_django(
     settings_module: str = "carbon_txt.web.config.settings.development",
     plugins_dir: Optional[str] = None,
 ):
     """Configure Django settings programmatically"""
+    django, settings, _, _ = _check_web_deps()
     if plugins_dir is not None:
         os.environ.setdefault("CARBON_TXT_PLUGINS_DIR", plugins_dir)
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)
     django.setup()
+    return settings
 
 
 @app.command()
@@ -201,6 +226,9 @@ def serve(
     ),
 ):
     """Run the carbon.txt validator web server"""
+
+    # Check web deps and get django components
+    django, settings, execute_from_command_line, _ = _check_web_deps()
 
     try:
         # override the prod / non prod switch if a custom settings module is provided

--- a/src/carbon_txt/process_ai_model_card.py
+++ b/src/carbon_txt/process_ai_model_card.py
@@ -1,6 +1,5 @@
 from .hookspecs import hookimpl
 from .http_client import HTTPClient
-from .processors import GreenwebAIModelCardProcessor
 from .schemas.version_0_5 import Disclosure
 import logging
 from typing import Optional
@@ -22,6 +21,13 @@ def log_safely(log_message: str, logs: Optional[list], level=logging.INFO):
 
 plugin_name = "ai-model-card_greenweb"
 
+#Guarded import - the AI model card processor requires the 'ai_model_cards' extra
+try:
+    from .processors.ai_model_card import GreenwebAIModelCardProcessor
+    AI_MODEL_CARD_PROCESSOR_AVAILABLE = True
+except ImportError:
+    AI_MODEL_CARD_PROCESSOR_AVAILABLE = False
+    GreenwebAIModelCardProcessor = None # type: ignore
 
 @hookimpl
 def process_document(
@@ -36,6 +42,14 @@ def process_document(
         logs=logs,
     )
     if document.doc_type == "ai-model-card":
+        if not AI_MODEL_CARD_PROCESSOR_AVAILABLE:
+            log_safely(
+                f"{plugin_name}: AI model card found but the 'ai_model_cards' extra is not installed. "
+                f"Install it with: uv pip install 'carbon-txt[ai_model_cards]'",
+                logs=logs,
+                level=logging.WARNING,
+            )
+            return {"logs": logs}
         log_safely(
             f"{__name__}: AI model card found. Processing document: {document}",
             logs=logs,

--- a/src/carbon_txt/process_csrd_document.py
+++ b/src/carbon_txt/process_csrd_document.py
@@ -1,11 +1,10 @@
-from .hookspecs import hookimpl
-from .schemas.common import Disclosure
-from .processors import GreenwebCSRDProcessor
 import logging
 from typing import Optional
 
-
 from structlog import get_logger
+
+from .hookspecs import hookimpl
+from .schemas.common import Disclosure
 
 logger = get_logger()
 
@@ -20,6 +19,15 @@ def log_safely(log_message: str, logs: Optional[list], level=logging.INFO):
 
 
 plugin_name = "csrd_greenweb"
+
+# Guarded import - the CSRD processor requires the 'csrd' extra
+try:
+    from .processors.csrd_document import GreenwebCSRDProcessor
+
+    CSRD_PROCESSOR_AVAILABLE = True
+except ImportError:
+    CSRD_PROCESSOR_AVAILABLE = False
+    GreenwebCSRDProcessor = None  # type: ignore
 
 
 @hookimpl
@@ -37,6 +45,15 @@ def process_document(
     )
 
     if document.doc_type == "csrd-report":
+        if not CSRD_PROCESSOR_AVAILABLE:
+            log_safely(
+                f"{plugin_name}: CSRD Report found but the 'csrd' extra is not installed. "
+                f"Install it with: uv pip install 'carbon-txt[csrd]'",
+                logs=logs,
+                level=logging.WARNING,
+            )
+            return {"logs": logs}
+
         log_safely(
             f"{__name__}: CSRD Report found. Processing report with Arelle: {document}",
             logs=logs,

--- a/src/carbon_txt/processors/__init__.py
+++ b/src/carbon_txt/processors/__init__.py
@@ -1,1 +1,0 @@
-from .ai_model_card import GreenwebAIModelCardProcessor as GreenwebAIModelCardProcessor

--- a/src/carbon_txt/processors/__init__.py
+++ b/src/carbon_txt/processors/__init__.py
@@ -1,2 +1,1 @@
-from .csrd_document import GreenwebCSRDProcessor as GreenwebCSRDProcessor
 from .ai_model_card import GreenwebAIModelCardProcessor as GreenwebAIModelCardProcessor

--- a/src/carbon_txt/processors/ai_model_card.py
+++ b/src/carbon_txt/processors/ai_model_card.py
@@ -1,9 +1,6 @@
 import logging
 from typing import Callable, Optional, TypeAlias
 
-import frontmatter
-from mistletoe import Document
-from mistletoe.block_token import Heading
 from pydantic import BaseModel
 from structlog import get_logger
 
@@ -13,6 +10,30 @@ from ..http_client import HTTPClient
 
 logger = get_logger()
 
+
+try: #Guarded imports for the "ai_model_cards" optional dependency group
+    import frontmatter
+    from mistletoe import Document
+    from mistletoe.block_token import Heading
+    OPTIONAL_DEPENDENCIES_AVAILABLE = True
+except ImportError:
+    Document = None
+    Heading = None
+    frontmatter = None
+    OPTIONAL_DEPENDENCIES_AVAILABLE = False
+
+class OptionalDependenciesNotInstalledError(ImportError):
+    """Raised when the ai_model_cards optional dependencies are not installed"""
+
+    pass
+
+def _require_optional_dependencies():
+    """Check the optional dependencies are installed, and if not raise a helpful error message."""
+    if not OPTIONAL_DEPENDENCIES_AVAILABLE:
+        raise OptionalDependenciesNotInstalledError(
+            "The AI model card processor requires the 'ai_model_cards extra to be installed"
+            "Install it with : uv pip install 'carbon-txt[ai_model_cards]'"
+        )
 
 def log_safely(log_message: str, logs: Optional[list], level=logging.INFO):
     """
@@ -101,6 +122,9 @@ class GreenwebAIModelCardProcessor:
         logs: Optional[list[str]] = None,
         http_client: Optional[HTTPClient] = None,
     ):
+
+        _require_optional_dependencies()
+
         if http_client is None:
             http_client = HTTPClient()
 

--- a/src/carbon_txt/processors/csrd_document.py
+++ b/src/carbon_txt/processors/csrd_document.py
@@ -1,10 +1,10 @@
 import datetime
-from pydantic import BaseModel
-
 import typing
-from ..exceptions import NoMatchingDatapointsError, NoLoadableCSRDFile
 
 import structlog
+from pydantic import BaseModel
+
+from ..exceptions import NoLoadableCSRDFile, NoMatchingDatapointsError
 
 logger = structlog.getLogger(__name__)
 
@@ -72,7 +72,7 @@ class ArelleProcessor:
     """
 
     report_url: str
-    xbrls: list
+    xbrls: list["ModelXbrl.ModelXbrl"]
 
     def __init__(self, report_url: str) -> None:
         """
@@ -112,12 +112,12 @@ class ArelleProcessor:
                 )
             session.close()
 
-    def parsed_reports(self) -> list:
+    def parsed_reports(self) -> list["ModelXbrl.ModelXbrl"]:
         """
         Return the parsed reports from the Arelle session. for querying.
 
         Returns:
-            list: A list of parsed reports from the Arelle session.
+            list[ModelXbrl.ModelXbrl]: A list of parsed reports from the Arelle session.
 
         """
         return self.xbrls

--- a/src/carbon_txt/processors/csrd_document.py
+++ b/src/carbon_txt/processors/csrd_document.py
@@ -1,9 +1,4 @@
 import datetime
-from arelle import (  # type: ignore
-    ModelXbrl,
-)
-from arelle.api.Session import Session  # type: ignore
-from arelle.RuntimeOptions import RuntimeOptions  # type: ignore
 from pydantic import BaseModel
 
 import typing
@@ -12,6 +7,37 @@ from ..exceptions import NoMatchingDatapointsError, NoLoadableCSRDFile
 import structlog
 
 logger = structlog.getLogger(__name__)
+
+
+# Guarded arelle imports - these are only available when the 'csrd' extra is installed
+try:
+    from arelle import (  # type: ignore
+        ModelXbrl,
+    )
+    from arelle.api.Session import Session  # type: ignore
+    from arelle.RuntimeOptions import RuntimeOptions  # type: ignore
+
+    ARELLE_AVAILABLE = True
+except ImportError:
+    ARELLE_AVAILABLE = False
+    ModelXbrl = None  # type: ignore
+    Session = None  # type: ignore
+    RuntimeOptions = None  # type: ignore
+
+
+class ArelleNotInstalledError(ImportError):
+    """Raised when arelle is required but not installed."""
+
+    pass
+
+
+def _require_arelle():
+    """Check that arelle is installed, raising a helpful error if not."""
+    if not ARELLE_AVAILABLE:
+        raise ArelleNotInstalledError(
+            "The CSRD processor requires the 'csrd' extra to be installed. "
+            "Install it with: uv pip install 'carbon-txt[csrd]'"
+        )
 
 
 class DataPoint(BaseModel):
@@ -46,7 +72,7 @@ class ArelleProcessor:
     """
 
     report_url: str
-    xbrls: list[ModelXbrl.ModelXbrl]
+    xbrls: list
 
     def __init__(self, report_url: str) -> None:
         """
@@ -59,6 +85,7 @@ class ArelleProcessor:
             report_url (str): The URL of the report to process
 
         """
+        _require_arelle()
 
         self.report_url = report_url
 
@@ -85,12 +112,12 @@ class ArelleProcessor:
                 )
             session.close()
 
-    def parsed_reports(self) -> list[ModelXbrl.ModelXbrl]:
+    def parsed_reports(self) -> list:
         """
         Return the parsed reports from the Arelle session. for querying.
 
         Returns:
-            list[ModelXbrl.ModelXbrl]: A list of parsed reports from the Arelle session.
+            list: A list of parsed reports from the Arelle session.
 
         """
         return self.xbrls
@@ -266,4 +293,6 @@ class GreenwebCSRDProcessor:
         return document_results
 
 
-assert isinstance(GreenwebCSRDProcessor(), CSRDProcessorProtocol)
+# Protocol assertion only runs when arelle is available
+if ARELLE_AVAILABLE:
+    assert isinstance(GreenwebCSRDProcessor(), CSRDProcessorProtocol)

--- a/tests/test_processor_ai_model_card.py
+++ b/tests/test_processor_ai_model_card.py
@@ -4,7 +4,7 @@ import unittest
 import pytest
 from httpx import HTTPError
 
-from carbon_txt.processors import GreenwebAIModelCardProcessor
+from carbon_txt.processors.ai_model_card import GreenwebAIModelCardProcessor
 
 
 def model_card_fixture(filename):

--- a/uv.lock
+++ b/uv.lock
@@ -147,29 +147,45 @@ name = "carbon-txt"
 version = "0.0.27"
 source = { editable = "." }
 dependencies = [
-    { name = "arelle-release" },
-    { name = "django-cors-headers" },
-    { name = "django-environ" },
-    { name = "django-ninja" },
-    { name = "django-structlog" },
-    { name = "django-stubs", extra = ["compatible-mypy"] },
     { name = "dnspython" },
-    { name = "granian" },
     { name = "httpx" },
     { name = "mistletoe" },
     { name = "pluggy" },
     { name = "pydantic-extra-types" },
     { name = "python-frontmatter" },
     { name = "rich" },
-    { name = "sentry-sdk", extra = ["django"] },
+    { name = "structlog" },
     { name = "tldextract" },
     { name = "tomlkit" },
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+all = [
+    { name = "arelle-release" },
+    { name = "django-cors-headers" },
+    { name = "django-environ" },
+    { name = "django-ninja" },
+    { name = "django-structlog" },
+    { name = "granian" },
+    { name = "sentry-sdk", extra = ["django"] },
+]
+csrd = [
+    { name = "arelle-release" },
+]
+web = [
+    { name = "django-cors-headers" },
+    { name = "django-environ" },
+    { name = "django-ninja" },
+    { name = "django-structlog" },
+    { name = "granian" },
+    { name = "sentry-sdk", extra = ["django"] },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "ansible" },
+    { name = "django-stubs", extra = ["compatible-mypy"] },
     { name = "furo" },
     { name = "ipdb" },
     { name = "marimo" },
@@ -188,29 +204,32 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "arelle-release", specifier = ">=2.36.3" },
-    { name = "django-cors-headers", specifier = ">=4.6.0" },
-    { name = "django-environ", specifier = ">=0.11.2" },
-    { name = "django-ninja", specifier = ">=1.3.0" },
-    { name = "django-structlog", specifier = ">=9.0.0" },
-    { name = "django-stubs", extras = ["compatible-mypy"], specifier = ">=5.1.1" },
+    { name = "arelle-release", marker = "extra == 'csrd'", specifier = ">=2.36.3" },
+    { name = "carbon-txt", extras = ["csrd", "web"], marker = "extra == 'all'" },
+    { name = "django-cors-headers", marker = "extra == 'web'", specifier = ">=4.6.0" },
+    { name = "django-environ", marker = "extra == 'web'", specifier = ">=0.11.2" },
+    { name = "django-ninja", marker = "extra == 'web'", specifier = ">=1.3.0" },
+    { name = "django-structlog", marker = "extra == 'web'", specifier = ">=9.0.0" },
     { name = "dnspython", specifier = ">=2.7.0" },
-    { name = "granian", specifier = ">=1.6.2" },
+    { name = "granian", marker = "extra == 'web'", specifier = ">=1.6.2" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "mistletoe", specifier = ">=1.5.1" },
     { name = "pluggy", specifier = ">=1.5.0" },
     { name = "pydantic-extra-types", specifier = ">=2.10.3" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "rich", specifier = ">=13.9.2" },
-    { name = "sentry-sdk", extras = ["django"], specifier = ">=2.18.0" },
+    { name = "sentry-sdk", extras = ["django"], marker = "extra == 'web'", specifier = ">=2.18.0" },
+    { name = "structlog", specifier = ">=25.3.0" },
     { name = "tldextract", specifier = ">=5.3.0" },
     { name = "tomlkit", specifier = ">=0.14.0" },
     { name = "typer", specifier = ">=0.12.5" },
 ]
+provides-extras = ["csrd", "web", "all"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "ansible", specifier = ">=11.5.0" },
+    { name = "django-stubs", extras = ["compatible-mypy"], specifier = ">=5.1.1" },
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "ipdb", specifier = ">=0.13.13" },
     { name = "marimo", specifier = ">=0.9.23" },

--- a/uv.lock
+++ b/uv.lock
@@ -149,10 +149,8 @@ source = { editable = "." }
 dependencies = [
     { name = "dnspython" },
     { name = "httpx" },
-    { name = "mistletoe" },
     { name = "pluggy" },
     { name = "pydantic-extra-types" },
-    { name = "python-frontmatter" },
     { name = "rich" },
     { name = "structlog" },
     { name = "tldextract" },
@@ -161,6 +159,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+ai-model-cards = [
+    { name = "mistletoe" },
+    { name = "python-frontmatter" },
+]
 all = [
     { name = "arelle-release" },
     { name = "django-cors-headers" },
@@ -168,6 +170,8 @@ all = [
     { name = "django-ninja" },
     { name = "django-structlog" },
     { name = "granian" },
+    { name = "mistletoe" },
+    { name = "python-frontmatter" },
     { name = "sentry-sdk", extra = ["django"] },
 ]
 csrd = [
@@ -206,7 +210,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "arelle-release", marker = "extra == 'csrd'", specifier = ">=2.36.3" },
-    { name = "carbon-txt", extras = ["csrd", "web"], marker = "extra == 'all'" },
+    { name = "carbon-txt", extras = ["csrd", "web", "ai-model-cards"], marker = "extra == 'all'" },
     { name = "django-cors-headers", marker = "extra == 'web'", specifier = ">=4.6.0" },
     { name = "django-environ", marker = "extra == 'web'", specifier = ">=0.11.2" },
     { name = "django-ninja", marker = "extra == 'web'", specifier = ">=1.3.0" },
@@ -214,10 +218,10 @@ requires-dist = [
     { name = "dnspython", specifier = ">=2.7.0" },
     { name = "granian", marker = "extra == 'web'", specifier = ">=1.6.2" },
     { name = "httpx", specifier = ">=0.27.2" },
-    { name = "mistletoe", specifier = ">=1.5.1" },
+    { name = "mistletoe", marker = "extra == 'ai-model-cards'", specifier = ">=1.5.1" },
     { name = "pluggy", specifier = ">=1.5.0" },
     { name = "pydantic-extra-types", specifier = ">=2.10.3" },
-    { name = "python-frontmatter", specifier = ">=1.1.0" },
+    { name = "python-frontmatter", marker = "extra == 'ai-model-cards'", specifier = ">=1.1.0" },
     { name = "rich", specifier = ">=13.9.2" },
     { name = "sentry-sdk", extras = ["django"], marker = "extra == 'web'", specifier = ">=2.18.0" },
     { name = "structlog", specifier = ">=25.3.0" },
@@ -225,7 +229,7 @@ requires-dist = [
     { name = "tomlkit", specifier = ">=0.14.0" },
     { name = "typer", specifier = ">=0.12.5" },
 ]
-provides-extras = ["csrd", "web", "all"]
+provides-extras = ["csrd", "web", "ai-model-cards", "all"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -185,6 +185,7 @@ web = [
 [package.dev-dependencies]
 dev = [
     { name = "ansible" },
+    { name = "carbon-txt", extra = ["all"] },
     { name = "django-stubs", extra = ["compatible-mypy"] },
     { name = "furo" },
     { name = "ipdb" },
@@ -229,6 +230,7 @@ provides-extras = ["csrd", "web", "all"]
 [package.metadata.requires-dev]
 dev = [
     { name = "ansible", specifier = ">=11.5.0" },
+    { name = "carbon-txt", extras = ["all"] },
     { name = "django-stubs", extras = ["compatible-mypy"], specifier = ">=5.1.1" },
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "ipdb", specifier = ">=0.13.13" },


### PR DESCRIPTION
hey @timcowlishaw  I spoke to Han about breaking up the carbon.txt validator into set of optional installs.

It turns out that I had had a stab at this last week on the weekend, purely out of curiousity to see how complicated it would be. I ended up implementing the change.

See the [rendered ADR for the proposed changes and motivation](https://github.com/thegreenwebfoundation/carbon-txt-validator/blob/3d01a3e482cbf75d98e6f94f026e3a083fe83f46/docs/adrs/05_optional_dependencies.md).




The machine generate summary of code changes is below.

---

This pull request introduces a major refactor of how dependencies are managed and documented in the `carbon-txt` project. The core package is now much smaller by default, and optional features (web server, CSRD processing) are grouped into installable "extras". This change is reflected throughout the documentation, configuration, and deployment scripts, and is accompanied by a detailed architectural decision record (ADR). There are also some smaller fixes and improvements.

**Dependency management overhaul:**

- **Dependencies are now split into optional extras**: The base `carbon-txt` package installs only the core dependencies (~22 MB). The `[web]` extra includes Django and web server dependencies, `[csrd]` includes Arelle for CSRD processing, and `[all]` installs everything. This reduces the default install size by ~90%. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L16-R42) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L46-R52) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R68) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13-R29)
- **Development dependencies migrated**: Dev dependencies are now managed using the modern `[dependency-groups] dev` format (PEP 735), and type stubs for Django are moved to dev dependencies to reduce runtime footprint. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L46-R52) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R68) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13-R29)

**Documentation updates:**

- **Installation and usage docs updated for extras**: All documentation now explains the new optional extras, with clear tables, usage instructions, and admonitions about which features require which extras. This includes `README.md`, `docs/installation.md`, `docs/deployment.md`, `docs/usage.md`, `docs/plugins.md`, and `docs/using_plugins.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R84) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R107) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R124) [[4]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L3-R64) [[5]](diffhunk://#diff-7f6254f34e124b6ff67f63aacb73b5252aa8e2b8afe712f48cdd3b32a24f908cR11-R23) [[6]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L200-R213) [[7]](diffhunk://#diff-416ed26bd34c304ad067cce7817d8cd1eb513c3b096a3761217b2d0297c6ffb1L21-R33) [[8]](diffhunk://#diff-155cddc301c9c51e8c2e4d0c8eade8051f4d91ae69eefc041b03023e84576705L9-R22) [[9]](diffhunk://#diff-155cddc301c9c51e8c2e4d0c8eade8051f4d91ae69eefc041b03023e84576705R98-R108)
- **ADR 5 added**: A comprehensive architectural decision record (`docs/adrs/05_optional_dependencies.md`) documents the rationale, tradeoffs, and consequences of splitting dependencies into extras.

**Code and deployment improvements:**

- **CLI and import changes**: The `GreenwebCSRDProcessor` is no longer exported from `carbon_txt.processors` and must be imported directly from `carbon_txt.processors.csrd_document`. The CLI now uses `os.environ` for config instead of `django-environ`, further reducing core dependencies.
- **Deployment scripts updated**: Ansible and runbook scripts now use the `[all]` extra to ensure all features are available when needed. [[1]](diffhunk://#diff-0e167d6e14f0958bd57a26a6e7be70a4d55e825ed89c8628f32ca08d3936f544L3-R4) [[2]](diffhunk://#diff-bba543a809d32babfc0199f7b0431b8bdd8d9948c6df1613f4aaafc83c6a4072L38-R42)

**Bug fixes:**

- **Documentation build path fix**: Fixed a bug in `docs/conf.py` that affected path resolution when building documentation outside the project root.
- **Docs formatting and clarity**: Various formatting fixes and clarifications across documentation files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R84) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R107) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R124)

---

**Dependency management:**
- Split dependencies into optional extras (`[web]`, `[csrd]`, `[all]`) for a much smaller core install and clearer feature targeting. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L16-R42) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L46-R52) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R68) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13-R29)
- Migrated dev dependencies to `[dependency-groups] dev` and moved Django stubs out of runtime dependencies. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L46-R52) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R68) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13-R29)

**Documentation:**
- Updated all install and usage docs to explain and demonstrate the new extras-based install model, including clear admonitions and tables. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R84) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R107) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R124) [[4]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L3-R64) [[5]](diffhunk://#diff-7f6254f34e124b6ff67f63aacb73b5252aa8e2b8afe712f48cdd3b32a24f908cR11-R23) [[6]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L200-R213) [[7]](diffhunk://#diff-416ed26bd34c304ad067cce7817d8cd1eb513c3b096a3761217b2d0297c6ffb1L21-R33) [[8]](diffhunk://#diff-155cddc301c9c51e8c2e4d0c8eade8051f4d91ae69eefc041b03023e84576705L9-R22) [[9]](diffhunk://#diff-155cddc301c9c51e8c2e4d0c8eade8051f4d91ae69eefc041b03023e84576705R98-R108)
- Added ADR 5 to document the decision and tradeoffs for splitting dependencies into extras.

**Code and deployment:**
- Changed import/export of `GreenwebCSRDProcessor` and replaced `django-environ` with `os.environ` in the CLI.
- Updated Ansible and runbook scripts to use `[all]` extra for full deployments. [[1]](diffhunk://#diff-0e167d6e14f0958bd57a26a6e7be70a4d55e825ed89c8628f32ca08d3936f544L3-R4) [[2]](diffhunk://#diff-bba543a809d32babfc0199f7b0431b8bdd8d9948c6df1613f4aaafc83c6a4072L38-R42)

**Bug fixes:**
- Fixed documentation build path issue in `docs/conf.py`.